### PR TITLE
Fix venv creation failure caused by QGIS SSL_CERT_DIR on Windows

### DIFF
--- a/timelapse/core/uv_manager.py
+++ b/timelapse/core/uv_manager.py
@@ -258,6 +258,14 @@ def verify_uv():
         env = os.environ.copy()
         env.pop("PYTHONPATH", None)
         env.pop("PYTHONHOME", None)
+        # Strip QGIS SSL variables that may point to non-existent paths
+        for var in (
+            "SSL_CERT_DIR",
+            "SSL_CERT_FILE",
+            "REQUESTS_CA_BUNDLE",
+            "CURL_CA_BUNDLE",
+        ):
+            env.pop(var, None)
 
         kwargs = {}
         if sys.platform == "win32":

--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -67,6 +67,12 @@ def _get_clean_env_for_venv():
         "PROJ_LIB",
         "GDAL_DATA",
         "GDAL_DRIVER_PATH",
+        # SSL/CA certificate variables -- QGIS may set these to
+        # QGIS-internal paths that do not exist outside QGIS.
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
     ]
     for key in vars_to_remove:
         env.pop(key, None)
@@ -90,6 +96,34 @@ def _get_subprocess_kwargs():
         kwargs["startupinfo"] = startupinfo
         kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
     return kwargs
+
+
+def _strip_stderr_warnings(stderr):
+    """Remove known non-fatal warning lines from stderr.
+
+    Some tools (e.g., uv) emit warnings to stderr that are not actual errors.
+    Stripping these ensures the real error message is visible when stderr is
+    truncated for display.
+
+    Args:
+        stderr: Raw stderr string from a subprocess.
+
+    Returns:
+        The stderr string with known warning lines removed.
+    """
+    if not stderr:
+        return stderr
+    warning_prefixes = (
+        "warning: Ignoring invalid",
+        "warning: Failed to query",
+    )
+    lines = stderr.splitlines()
+    filtered = [
+        line
+        for line in lines
+        if not any(line.strip().startswith(prefix) for prefix in warning_prefixes)
+    ]
+    return "\n".join(filtered).strip()
 
 
 # ---------------------------------------------------------------------------
@@ -380,7 +414,8 @@ def create_venv(venv_dir=None, progress_callback=None):
                             err = ensurepip_result.stderr or ensurepip_result.stdout
                             _log(f"ensurepip failed: {err[:200]}", Qgis.Warning)
                             _cleanup_partial_venv(venv_dir)
-                            return False, f"Failed to bootstrap pip: {err[:200]}"
+                            user_err = _strip_stderr_warnings(err) or err
+                            return False, f"Failed to bootstrap pip: {user_err[:300]}"
                     except Exception as e:
                         _log(f"ensurepip exception: {e}", Qgis.Warning)
                         _cleanup_partial_venv(venv_dir)
@@ -395,7 +430,8 @@ def create_venv(venv_dir=None, progress_callback=None):
             )
             _log(f"Failed to create venv: {error_msg}", Qgis.Critical)
             _cleanup_partial_venv(venv_dir)
-            return False, f"Failed to create venv: {error_msg[:200]}"
+            user_msg = _strip_stderr_warnings(error_msg) or error_msg
+            return False, f"Failed to create venv: {user_msg[:300]}"
 
     except subprocess.TimeoutExpired:
         _log("Virtual environment creation timed out", Qgis.Critical)

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -2,7 +2,7 @@
 name=Timelapse
 qgisMinimumVersion=3.28
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, and MODIS NDVI) using Google Earth Engine
-version=0.8.0
+version=0.8.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -32,6 +32,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.8.1:
+        - Fix issue with venv creation on Windows
     0.8.0:
         - Add settings dock and fix ee refresh after dependency install (#39)
     0.7.0:


### PR DESCRIPTION
## Summary
- Strip SSL/CA environment variables (`SSL_CERT_DIR`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`) from subprocess calls in `venv_manager.py` and `uv_manager.py`
- Add `_strip_stderr_warnings()` helper to filter non-fatal `uv` warnings from stderr, so the real error is visible in truncated user-facing messages
- Increase error message truncation limit from 200 to 300 characters

## Context
A Windows user reported that "Install Dependencies" fails with:
> Failed to create venv: warning: Ignoring invalid `SSL_CERT_DIR`. The directory does not exist.: C:\PROGRA~1\QGIS34~1.15\apps\openssl\certs

QGIS on Windows sets `SSL_CERT_DIR` to a QGIS-internal path that may not exist. The plugin's `_get_clean_env_for_venv()` already strips QGIS-specific variables before subprocess calls, but was missing SSL-related ones. Both `uv` and `pip` bundle their own CA certificates, so stripping these variables does not break HTTPS downloads from PyPI.

## Test plan
- [ ] On Windows with QGIS installed, verify venv creation succeeds without the SSL warning
- [ ] Verify packages install correctly after the fix (SSL stripping does not break PyPI downloads)
- [ ] On Linux/macOS, verify no regression (these variables are typically unset)