### PR TITLE
Add Qt6/QGIS 4 compatibility while keeping QGIS 3.28+ support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+    push:
+        branches: ["**"]
+    pull_request:
+        branches: [main]
+
+jobs:
+    pre-commit:
+        name: pre-commit
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - uses: pre-commit/action@v3.0.1
+
+    bandit:
+        name: Bandit security scan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - name: Install Bandit
+              run: pip install bandit
+            - name: Run Bandit (matches plugins.qgis.org security scan)
+              run: bandit -r timelapse
+
+    pyqt6-smoke:
+        name: PyQt6 import smoke
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.11", "3.12", "3.13"]
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install Qt6 runtime libs
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+            - name: Install PyQt6 and pytest
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install PyQt6 pytest
+            - name: Run import smoke tests
+              run: pytest tests -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,10 @@ repos:
       rev: 0.9.1
       hooks:
           - id: nbstripout
+
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.9.4
+      hooks:
+          - id: bandit
+            args: ["-r", "timelapse"]
+            pass_filenames: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,103 @@
+"""Shared pytest fixtures.
+
+Stubs the ``qgis`` package so the plugin's modules can be imported without a
+running QGIS instance. The stub reproduces the real ``qgis.PyQt`` shim
+behavior on Qt6: it re-exports ``QAction``, ``QActionGroup`` and ``QShortcut``
+from ``PyQt6.QtGui`` under ``qgis.PyQt.QtWidgets`` (they moved out of
+``QtWidgets`` in Qt6).
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import PyQt6.QtCore
+import PyQt6.QtGui
+import PyQt6.QtNetwork
+import PyQt6.QtWidgets
+
+
+def _install_qgis_stub() -> None:
+    qgis = types.ModuleType("qgis")
+    qgis.__path__ = []
+    sys.modules["qgis"] = qgis
+
+    qgis_pyqt = types.ModuleType("qgis.PyQt")
+    qgis_pyqt.__path__ = []
+    sys.modules["qgis.PyQt"] = qgis_pyqt
+    qgis.PyQt = qgis_pyqt
+
+    pyqt_submodules = {
+        "QtCore": PyQt6.QtCore,
+        "QtGui": PyQt6.QtGui,
+        "QtNetwork": PyQt6.QtNetwork,
+        "QtWidgets": PyQt6.QtWidgets,
+    }
+    for name, real in pyqt_submodules.items():
+        alias = types.ModuleType(f"qgis.PyQt.{name}")
+        for attr in dir(real):
+            if not attr.startswith("_"):
+                setattr(alias, attr, getattr(real, attr))
+        sys.modules[f"qgis.PyQt.{name}"] = alias
+        setattr(qgis_pyqt, name, alias)
+
+    # Qt6: QAction, QActionGroup, and QShortcut live in QtGui. The real
+    # qgis.PyQt.QtWidgets shim re-exports them, so mirror that here.
+    qtwidgets_alias = sys.modules["qgis.PyQt.QtWidgets"]
+    for attr in ("QAction", "QActionGroup", "QShortcut"):
+        setattr(qtwidgets_alias, attr, getattr(PyQt6.QtGui, attr))
+
+    for submodule in ("QtSvg", "QtWebEngineWidgets"):
+        alias = MagicMock()
+        sys.modules[f"qgis.PyQt.{submodule}"] = alias
+        setattr(qgis_pyqt, submodule, alias)
+
+    class _AutoTypeMeta(type):
+        """Metaclass that auto-creates nested classes on attribute access.
+
+        Lets ``Qgis.MessageLevel.Info`` resolve at import time without needing
+        a real QGIS install: each access materializes a real ``type``.
+        """
+
+        def __getattr__(cls, name):
+            if name.startswith("__"):
+                raise AttributeError(name)
+            cache = cls.__dict__.get("_auto_cache")
+            if cache is None:
+                cache = {}
+                type.__setattr__(cls, "_auto_cache", cache)
+            sub = cache.get(name)
+            if sub is None:
+                sub = _AutoTypeMeta(name, (), {})
+                cache[name] = sub
+            return sub
+
+    class _AutoTypeModule(types.ModuleType):
+        """qgis.core/gui/utils stub that auto-creates real classes on attribute access.
+
+        ``pyqtSignal(QgsRectangle)`` and ``class X(QgsMapToolEmitPoint)`` both
+        need real type objects (not MagicMock) at import time, so every access
+        materializes a brand-new ``type`` and caches it.
+        """
+
+        def __init__(self, fullname: str) -> None:
+            super().__init__(fullname)
+            self.__spec__ = None
+            self._cache: dict = {}
+
+        def __getattr__(self, name: str):
+            if name.startswith("__"):
+                raise AttributeError(name)
+            cached = self._cache.get(name)
+            if cached is None:
+                cached = _AutoTypeMeta(name, (), {})
+                self._cache[name] = cached
+            return cached
+
+    for name in ("core", "gui", "utils"):
+        stub = _AutoTypeModule(f"qgis.{name}")
+        sys.modules[f"qgis.{name}"] = stub
+        setattr(qgis, name, stub)
+
+
+_install_qgis_stub()

--- a/tests/test_pyqt6_imports.py
+++ b/tests/test_pyqt6_imports.py
@@ -1,0 +1,54 @@
+"""Import-smoke tests that verify every plugin module loads under PyQt6.
+
+This catches short-form Qt enum regressions (for example ``Qt.AlignCenter``
+instead of ``Qt.AlignmentFlag.AlignCenter``) which raise ``AttributeError`` in
+PyQt6 during class-body evaluation.
+
+The plugin package is auto-discovered: the first sibling directory of
+``tests/`` that contains a ``metadata.txt`` is treated as the plugin root,
+so this file does not need to be edited per-plugin.
+"""
+
+import importlib
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _find_plugin_root() -> pathlib.Path:
+    """Return the plugin package directory (the one with metadata.txt)."""
+    candidates = [
+        p.parent for p in REPO_ROOT.glob("*/metadata.txt") if p.parent.name != "tests"
+    ]
+    if not candidates:
+        raise RuntimeError(
+            "Could not locate a QGIS plugin package (no */metadata.txt found "
+            f"under {REPO_ROOT})."
+        )
+    if len(candidates) > 1:
+        raise RuntimeError(
+            f"Multiple plugin packages found under {REPO_ROOT}: {candidates}. "
+            "Set PLUGIN_ROOT explicitly in this file."
+        )
+    return candidates[0]
+
+
+PLUGIN_ROOT = _find_plugin_root()
+
+
+def _module_names():
+    """Yield dotted module names for every .py file under the plugin package."""
+    for path in sorted(PLUGIN_ROOT.rglob("*.py")):
+        rel = path.relative_to(PLUGIN_ROOT.parent).with_suffix("")
+        parts = rel.parts
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        yield ".".join(parts)
+
+
+@pytest.mark.parametrize("module_name", list(_module_names()))
+def test_module_imports_under_pyqt6(module_name):
+    """Each plugin module must import cleanly when qgis.PyQt maps to PyQt6."""
+    importlib.import_module(module_name)

--- a/timelapse/core/python_manager.py
+++ b/timelapse/core/python_manager.py
@@ -11,7 +11,7 @@ Source: https://github.com/astral-sh/python-build-standalone
 import os
 import sys
 import platform
-import subprocess
+import subprocess  # nosec B404 (validated list-form calls only; see _run_subprocess)
 import tarfile
 import zipfile
 import tempfile
@@ -36,12 +36,12 @@ PYTHON_VERSIONS = {
 }
 
 
-def _log(message, level=Qgis.Info):
+def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), "Timelapse", level=level)
 
@@ -212,7 +212,7 @@ def download_python_standalone(progress_callback=None, cancel_check=None):
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -253,7 +253,7 @@ def download_python_standalone(progress_callback=None, cancel_check=None):
         if success:
             if progress_callback:
                 progress_callback(100, f"Python {python_version} installed")
-            _log("Python standalone installed successfully", Qgis.Success)
+            _log("Python standalone installed successfully", Qgis.MessageLevel.Success)
             return True, f"Python {python_version} installed successfully"
         else:
             return False, f"Verification failed: {verify_msg}"
@@ -262,7 +262,7 @@ def download_python_standalone(progress_callback=None, cancel_check=None):
         return False, "Download cancelled"
     except Exception as e:
         error_msg = f"Installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
 
         if sys.platform == "win32":
             error_lower = str(e).lower()
@@ -320,7 +320,7 @@ def verify_standalone_python():
             startupinfo.wShowWindow = subprocess.SW_HIDE
             kwargs["startupinfo"] = startupinfo
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 (list-form, fixed code, no shell)
             [python_path, "-c", "import sys; print(sys.version)"],
             capture_output=True,
             text=True,
@@ -334,14 +334,20 @@ def verify_standalone_python():
             if not version_output.startswith(
                 f"{sys.version_info.major}.{sys.version_info.minor}"
             ):
-                _log(f"Python version mismatch: got {version_output}", Qgis.Warning)
+                _log(
+                    f"Python version mismatch: got {version_output}",
+                    Qgis.MessageLevel.Warning,
+                )
                 return False, f"Version mismatch: {version_output}"
 
-            _log(f"Verified Python standalone: {version_output}", Qgis.Success)
+            _log(
+                f"Verified Python standalone: {version_output}",
+                Qgis.MessageLevel.Success,
+            )
             return True, f"Python {version_output} verified"
         else:
             error = result.stderr or "Unknown error"
-            _log(f"Python verification failed: {error}", Qgis.Warning)
+            _log(f"Python verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -361,9 +367,9 @@ def remove_standalone_python():
 
     try:
         shutil.rmtree(STANDALONE_DIR)
-        _log("Removed standalone Python installation", Qgis.Success)
+        _log("Removed standalone Python installation", Qgis.MessageLevel.Success)
         return True, "Standalone Python removed"
     except Exception as e:
         error_msg = f"Failed to remove: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/timelapse/core/timelapse_core.py
+++ b/timelapse/core/timelapse_core.py
@@ -115,7 +115,7 @@ def _load_ee_credentials():
         return Credentials(
             token=None,
             refresh_token=refresh_token,
-            token_uri="https://oauth2.googleapis.com/token",
+            token_uri="https://oauth2.googleapis.com/token",  # nosec B106 (public Google OAuth2 endpoint, not a secret)
             client_id=data.get("client_id"),
             client_secret=data.get("client_secret"),
         )
@@ -173,7 +173,9 @@ def initialize_ee(project: str = None, force: bool = False) -> bool:
 
             settings = QSettings()
             project = settings.value("QgisTimelapse/project_id", "", type=str).strip()
-        except Exception:
+        except (
+            Exception
+        ):  # nosec B110 (best-effort QSettings read; falls through to get_ee_project below)
             pass
 
         if not project:
@@ -227,7 +229,9 @@ def try_auto_initialize_ee() -> bool:
 
         settings = QSettings()
         project = settings.value("QgisTimelapse/project_id", "", type=str).strip()
-    except Exception:
+    except (
+        Exception
+    ):  # nosec B110 (best-effort QSettings read; falls through to env var below)
         pass
 
     if not project:
@@ -1155,6 +1159,7 @@ def download_ee_video(
     Returns:
         Path to output GIF.
     """
+    import shutil
     import urllib.request
     import urllib.error
 
@@ -1164,16 +1169,26 @@ def download_ee_video(
     except Exception as e:
         raise RuntimeError(f"Failed to generate video URL: {e}") from e
 
+    # Earth Engine thumbnail URLs are always https; refuse anything else.
+    if not url.startswith("https://"):
+        raise RuntimeError(f"Refusing to download non-https video URL: {url}")
+
     # Download the GIF
     try:
-        urllib.request.urlretrieve(url, out_gif)
+        with urllib.request.urlopen(
+            url, timeout=120
+        ) as response:  # nosec B310 (https enforced above)
+            with open(out_gif, "wb") as out_file:
+                shutil.copyfileobj(response, out_file)
     except urllib.error.HTTPError as e:
         # Read the error response body for more details
         error_body = ""
         if hasattr(e, "read"):
             try:
                 error_body = e.read().decode("utf-8", errors="ignore")
-            except Exception:
+            except (
+                Exception
+            ):  # nosec B110 (best-effort body extraction; we re-raise RuntimeError below)
                 pass
         raise RuntimeError(
             f"Failed to download video: HTTP {e.code} {e.reason}. "
@@ -1277,12 +1292,12 @@ def add_text_to_gif(
     # Try to load a font
     try:
         font = ImageFont.truetype("arial.ttf", font_size)
-    except:
+    except (OSError, IOError):
         try:
             font = ImageFont.truetype(
                 "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", font_size
             )
-        except:
+        except (OSError, IOError):
             font = ImageFont.load_default()
 
     for i in range(n_frames):
@@ -1339,7 +1354,7 @@ def gif_to_mp4(in_gif: str, out_mp4: str) -> bool:
     Returns:
         True if successful, False otherwise.
     """
-    import subprocess
+    import subprocess  # nosec B404 (ffmpeg invoked with validated list-form args)
     import shutil
 
     # Check if PIL is available
@@ -1386,7 +1401,9 @@ def gif_to_mp4(in_gif: str, out_mp4: str) -> bool:
     ]
 
     try:
-        subprocess.run(cmd, check=True)
+        subprocess.run(
+            cmd, check=True
+        )  # nosec B603 (cmd is built from validated ffmpeg path + fixed flags)
         return os.path.exists(out_mp4)
     except subprocess.CalledProcessError:
         return False
@@ -2155,7 +2172,7 @@ def create_modis_ndvi_timelapse(
                     "Dec",
                 ]
                 text_sequence.append(f"{months[month-1]} {day:02d}")
-            except:
+            except (ValueError, TypeError, IndexError):
                 text_sequence.append(t)
 
         add_text_to_gif(

--- a/timelapse/core/uv_manager.py
+++ b/timelapse/core/uv_manager.py
@@ -11,7 +11,7 @@ import os
 import sys
 import platform
 import stat
-import subprocess
+import subprocess  # nosec B404 (validated list-form calls only; uv binary launched with controlled args)
 import tarfile
 import zipfile
 import tempfile
@@ -27,12 +27,12 @@ UV_DIR = os.path.join(CACHE_DIR, "uv")
 UV_VERSION = "0.10.6"
 
 
-def _log(message, level=Qgis.Info):
+def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), "Timelapse", level=level)
 
@@ -137,7 +137,7 @@ def download_uv(progress_callback=None, cancel_check=None):
                 )
             else:
                 error_msg = f"Download failed: {error_msg}"
-            _log(error_msg, Qgis.Critical)
+            _log(error_msg, Qgis.MessageLevel.Critical)
             return False, error_msg
 
         if cancel_check and cancel_check():
@@ -208,7 +208,7 @@ def download_uv(progress_callback=None, cancel_check=None):
         if success:
             if progress_callback:
                 progress_callback(100, f"uv {UV_VERSION} installed")
-            _log("uv installed successfully", Qgis.Success)
+            _log("uv installed successfully", Qgis.MessageLevel.Success)
             return True, f"uv {UV_VERSION} installed successfully"
         else:
             return False, f"Verification failed: {verify_msg}"
@@ -217,7 +217,7 @@ def download_uv(progress_callback=None, cancel_check=None):
         return False, "Download cancelled"
     except Exception as e:
         error_msg = f"uv installation failed: {str(e)}"
-        _log(error_msg, Qgis.Critical)
+        _log(error_msg, Qgis.MessageLevel.Critical)
         return False, error_msg
     finally:
         if os.path.exists(temp_path):
@@ -271,7 +271,7 @@ def verify_uv():
         if sys.platform == "win32":
             kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 (list-form, fixed args, no shell)
             [uv_path, "--version"],
             capture_output=True,
             text=True,
@@ -282,11 +282,11 @@ def verify_uv():
 
         if result.returncode == 0:
             version_output = result.stdout.strip()
-            _log(f"Verified uv: {version_output}", Qgis.Success)
+            _log(f"Verified uv: {version_output}", Qgis.MessageLevel.Success)
             return True, version_output
         else:
             error = result.stderr or "Unknown error"
-            _log(f"uv verification failed: {error}", Qgis.Warning)
+            _log(f"uv verification failed: {error}", Qgis.MessageLevel.Warning)
             return False, f"Verification failed: {error[:100]}"
 
     except subprocess.TimeoutExpired:
@@ -306,9 +306,9 @@ def remove_uv():
 
     try:
         shutil.rmtree(UV_DIR)
-        _log("Removed uv installation", Qgis.Success)
+        _log("Removed uv installation", Qgis.MessageLevel.Success)
         return True, "uv removed"
     except Exception as e:
         error_msg = f"Failed to remove uv: {str(e)}"
-        _log(error_msg, Qgis.Warning)
+        _log(error_msg, Qgis.MessageLevel.Warning)
         return False, error_msg

--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -11,7 +11,7 @@ import importlib.metadata
 import os
 import platform
 import shutil
-import subprocess
+import subprocess  # nosec B404 (validated list-form calls only; commands are pinned, not user input)
 import sys
 import time
 from typing import Callable, Optional, Tuple
@@ -29,12 +29,12 @@ REQUIRED_PACKAGES = [
 ]
 
 
-def _log(message, level=Qgis.Info):
+def _log(message, level=Qgis.MessageLevel.Info):
     """Log a message to the QGIS message log.
 
     Args:
         message: The message to log.
-        level: The log level (Qgis.Info, Qgis.Warning, Qgis.Critical).
+        level: The log level (Qgis.MessageLevel.Info, Qgis.MessageLevel.Warning, Qgis.MessageLevel.Critical).
     """
     QgsMessageLog.logMessage(str(message), "Timelapse", level=level)
 
@@ -307,7 +307,7 @@ def _get_system_python():
     if python_path and os.path.isfile(python_path):
         _log(
             f"Standalone Python unavailable, using system Python: {python_path}",
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
         return python_path
 
@@ -333,7 +333,10 @@ def _cleanup_partial_venv(venv_dir):
             shutil.rmtree(venv_dir, ignore_errors=True)
             _log(f"Cleaned up partial venv: {venv_dir}")
         except Exception:
-            _log(f"Could not clean up partial venv: {venv_dir}", Qgis.Warning)
+            _log(
+                f"Could not clean up partial venv: {venv_dir}",
+                Qgis.MessageLevel.Warning,
+            )
 
 
 def create_venv(venv_dir=None, progress_callback=None):
@@ -375,7 +378,7 @@ def create_venv(venv_dir=None, progress_callback=None):
 
         os.makedirs(os.path.dirname(venv_dir), exist_ok=True)
 
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 (cmd is built from validated python path + fixed venv args)
             cmd,
             capture_output=True,
             text=True,
@@ -385,7 +388,7 @@ def create_venv(venv_dir=None, progress_callback=None):
         )
 
         if result.returncode == 0:
-            _log("Virtual environment created successfully", Qgis.Success)
+            _log("Virtual environment created successfully", Qgis.MessageLevel.Success)
 
             # When using stdlib venv, ensure pip is available
             if not use_uv:
@@ -400,7 +403,7 @@ def create_venv(venv_dir=None, progress_callback=None):
                         "--upgrade",
                     ]
                     try:
-                        ensurepip_result = subprocess.run(
+                        ensurepip_result = subprocess.run(  # nosec B603 (list-form, fixed ensurepip args)
                             ensurepip_cmd,
                             capture_output=True,
                             text=True,
@@ -409,15 +412,21 @@ def create_venv(venv_dir=None, progress_callback=None):
                             **kwargs,
                         )
                         if ensurepip_result.returncode == 0:
-                            _log("pip bootstrapped via ensurepip", Qgis.Success)
+                            _log(
+                                "pip bootstrapped via ensurepip",
+                                Qgis.MessageLevel.Success,
+                            )
                         else:
                             err = ensurepip_result.stderr or ensurepip_result.stdout
-                            _log(f"ensurepip failed: {err[:200]}", Qgis.Warning)
+                            _log(
+                                f"ensurepip failed: {err[:200]}",
+                                Qgis.MessageLevel.Warning,
+                            )
                             _cleanup_partial_venv(venv_dir)
                             user_err = _strip_stderr_warnings(err) or err
                             return False, f"Failed to bootstrap pip: {user_err[:300]}"
                     except Exception as e:
-                        _log(f"ensurepip exception: {e}", Qgis.Warning)
+                        _log(f"ensurepip exception: {e}", Qgis.MessageLevel.Warning)
                         _cleanup_partial_venv(venv_dir)
                         return False, f"Failed to bootstrap pip: {str(e)[:200]}"
 
@@ -428,20 +437,22 @@ def create_venv(venv_dir=None, progress_callback=None):
             error_msg = (
                 result.stderr or result.stdout or f"Return code {result.returncode}"
             )
-            _log(f"Failed to create venv: {error_msg}", Qgis.Critical)
+            _log(f"Failed to create venv: {error_msg}", Qgis.MessageLevel.Critical)
             _cleanup_partial_venv(venv_dir)
             user_msg = _strip_stderr_warnings(error_msg) or error_msg
             return False, f"Failed to create venv: {user_msg[:300]}"
 
     except subprocess.TimeoutExpired:
-        _log("Virtual environment creation timed out", Qgis.Critical)
+        _log("Virtual environment creation timed out", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)
         return False, "Virtual environment creation timed out"
     except FileNotFoundError:
-        _log(f"Python executable not found: {system_python}", Qgis.Critical)
+        _log(
+            f"Python executable not found: {system_python}", Qgis.MessageLevel.Critical
+        )
         return False, f"Python not found: {system_python}"
     except Exception as e:
-        _log(f"Exception during venv creation: {str(e)}", Qgis.Critical)
+        _log(f"Exception during venv creation: {str(e)}", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)
         return False, f"Error: {str(e)[:200]}"
 
@@ -578,7 +589,7 @@ def install_dependencies(venv_dir=None, progress_callback=None, cancel_check=Non
     if not success:
         return False, error_msg
 
-    _log(f"Installed {total} package(s)", Qgis.Success)
+    _log(f"Installed {total} package(s)", Qgis.MessageLevel.Success)
 
     if progress_callback:
         progress_callback(90, "All packages installed")
@@ -603,7 +614,7 @@ def _run_install_subprocess(
         A tuple of (returncode: int, stdout: str, stderr: str).
             returncode is -1 if cancelled, -2 if timed out.
     """
-    proc = subprocess.Popen(
+    proc = subprocess.Popen(  # nosec B603 (cmd is list-form, no shell, args validated upstream)
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -713,7 +724,7 @@ def _run_install(
             _log(
                 f"SSL error installing dependencies via {installer}, "
                 f"retrying with trusted hosts",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             retry_cmd = cmd + ssl_flags
             returncode, stdout, retry_stderr = _run_install_subprocess(
@@ -735,7 +746,7 @@ def _run_install(
             _log(
                 f"Network error installing dependencies via {installer}, "
                 f"retrying in 5s...",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             time.sleep(5)
             returncode, stdout, retry_stderr = _run_install_subprocess(
@@ -850,7 +861,7 @@ def verify_venv(venv_dir=None, progress_callback=None):
         cmd = [python_path, "-c", verify_code]
 
         try:
-            result = subprocess.run(
+            result = subprocess.run(  # nosec B603 (list-form; verify_code is internal-controlled)
                 cmd,
                 capture_output=True,
                 text=True,
@@ -865,23 +876,25 @@ def verify_venv(venv_dir=None, progress_callback=None):
                 )
                 _log(
                     f"Package {package_name} verification failed: {error_detail}",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
                 return False, (
                     f"Package {package_name} is broken: {error_detail[:200]}"
                 )
 
         except subprocess.TimeoutExpired:
-            _log(f"Verification of {package_name} timed out", Qgis.Warning)
+            _log(f"Verification of {package_name} timed out", Qgis.MessageLevel.Warning)
             return False, f"Verification of {package_name} timed out"
         except Exception as e:
-            _log(f"Failed to verify {package_name}: {str(e)}", Qgis.Warning)
+            _log(
+                f"Failed to verify {package_name}: {str(e)}", Qgis.MessageLevel.Warning
+            )
             return False, f"Verification error: {package_name}"
 
     if progress_callback:
         progress_callback(100, "Verification complete")
 
-    _log("Virtual environment verified successfully", Qgis.Success)
+    _log("Virtual environment verified successfully", Qgis.MessageLevel.Success)
     return True, "Virtual environment ready"
 
 
@@ -903,13 +916,13 @@ def ensure_venv_packages_available():
         python_path = get_venv_python_path()
         _log(
             f"Venv does not exist: expected Python at {python_path}",
-            Qgis.Warning,
+            Qgis.MessageLevel.Warning,
         )
         return False
 
     site_packages = get_venv_site_packages()
     if site_packages is None:
-        _log(f"Venv site-packages not found in: {VENV_DIR}", Qgis.Warning)
+        _log(f"Venv site-packages not found in: {VENV_DIR}", Qgis.MessageLevel.Warning)
         return False
 
     path_was_missing = site_packages not in sys.path
@@ -1069,7 +1082,7 @@ def create_venv_and_install(progress_callback=None, cancel_check=None):
             if fallback and os.path.isfile(fallback):
                 _log(
                     f"Standalone download failed, using system Python: {fallback}",
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                 )
             else:
                 return False, f"Failed to download Python: {msg}"
@@ -1098,7 +1111,7 @@ def create_venv_and_install(progress_callback=None, cancel_check=None):
             # Non-fatal: fall back to pip for venv creation and installation
             _log(
                 f"uv download failed ({msg}), will use pip instead",
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
         else:
             _log("uv package installer ready")
@@ -1164,7 +1177,10 @@ def create_venv_and_install(progress_callback=None, cancel_check=None):
     if progress_callback:
         progress_callback(100, f"All dependencies installed in {elapsed_str}")
 
-    _log(f"All dependencies installed and verified in {elapsed_str}", Qgis.Success)
+    _log(
+        f"All dependencies installed and verified in {elapsed_str}",
+        Qgis.MessageLevel.Success,
+    )
     return True, f"All dependencies installed successfully in {elapsed_str}"
 
 
@@ -1193,7 +1209,7 @@ def remove_venv(venv_dir=None):
         _log(f"Removed venv: {venv_dir}")
         return True, "Virtual environment removed"
     except Exception as e:
-        _log(f"Failed to remove venv: {e}", Qgis.Warning)
+        _log(f"Failed to remove venv: {e}", Qgis.MessageLevel.Warning)
         return False, f"Failed to remove virtual environment:\n{e}"
 
 
@@ -1232,7 +1248,7 @@ def cleanup_old_venv_directories():
                     removed.append(marker)
                     _log(f"Removed old venv artifact: {marker}")
                 except Exception as e:
-                    _log(f"Failed to remove {marker}: {e}", Qgis.Warning)
+                    _log(f"Failed to remove {marker}: {e}", Qgis.MessageLevel.Warning)
 
         # Also remove other venv artifacts
         for name in ("deps_hash.txt", "include", "share"):
@@ -1244,7 +1260,9 @@ def cleanup_old_venv_directories():
                     else:
                         os.remove(path)
                     removed.append(path)
-                except Exception:
+                except (
+                    Exception
+                ):  # nosec B110 (best-effort cache cleanup; missing files are not actionable)
                     pass
 
     return removed
@@ -1311,7 +1329,7 @@ def authenticate_ee(
             return True, "Earth Engine authentication completed successfully"
         else:
             error = result.stderr or result.stdout or "Unknown error"
-            _log(f"EE authentication failed: {error[:200]}", Qgis.Warning)
+            _log(f"EE authentication failed: {error[:200]}", Qgis.MessageLevel.Warning)
             return False, f"Authentication failed: {error[:200]}"
 
     except subprocess.TimeoutExpired:

--- a/timelapse/dialogs/about_dialog.py
+++ b/timelapse/dialogs/about_dialog.py
@@ -67,7 +67,12 @@ class AboutDialog(QDialog):
             pixmap = QPixmap(icon_path)
             if not pixmap.isNull():
                 icon_label.setPixmap(
-                    pixmap.scaled(64, 64, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+                    pixmap.scaled(
+                        64,
+                        64,
+                        Qt.AspectRatioMode.KeepAspectRatio,
+                        Qt.TransformationMode.SmoothTransformation,
+                    )
                 )
                 header_layout.addWidget(icon_label)
 
@@ -169,7 +174,7 @@ seasonal variations, and more from various satellite data sources.</p>
             "<p style='color: gray; text-align: center;'>"
             "Licensed under the MIT License</p>"
         )
-        license_label.setAlignment(Qt.AlignCenter)
+        license_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(license_label)
 
         # Close button

--- a/timelapse/dialogs/dependency_dialog.py
+++ b/timelapse/dialogs/dependency_dialog.py
@@ -88,7 +88,7 @@ class DependencyDialog(QDialog):
         header_font.setPointSize(14)
         header_font.setBold(True)
         header.setFont(header_font)
-        header.setAlignment(Qt.AlignCenter)
+        header.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header)
 
         # Description
@@ -211,10 +211,10 @@ class DependencyDialog(QDialog):
                 self,
                 "Installation in Progress",
                 "An installation is in progress. " "Are you sure you want to cancel?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
-            if reply != QMessageBox.Yes:
+            if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
             self._install_worker.terminate()

--- a/timelapse/dialogs/settings_dock.py
+++ b/timelapse/dialogs/settings_dock.py
@@ -57,7 +57,9 @@ class SettingsDockWidget(QDockWidget):
         self._deps_worker = None
         self._auth_worker = None
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
 
         self._setup_ui()
         self._load_settings()
@@ -78,7 +80,7 @@ class SettingsDockWidget(QDockWidget):
         header_font.setPointSize(12)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header_label)
 
         # Tab widget for organized settings
@@ -516,11 +518,11 @@ class SettingsDockWidget(QDockWidget):
             self,
             "Reset Settings",
             "Are you sure you want to reset all settings to defaults?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         # Earth Engine

--- a/timelapse/dialogs/timelapse_dock.py
+++ b/timelapse/dialogs/timelapse_dock.py
@@ -324,13 +324,15 @@ class TimelapseDockWidget(QDockWidget):
         self.progress_timer = None
         self.ee_initialized = False
 
-        self.setAllowedAreas(Qt.LeftDockWidgetArea | Qt.RightDockWidgetArea)
+        self.setAllowedAreas(
+            Qt.DockWidgetArea.LeftDockWidgetArea | Qt.DockWidgetArea.RightDockWidgetArea
+        )
         self.setMinimumWidth(400)
 
         # Create main widget with scroll area
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
 
         main_widget = QWidget()
         self.setup_ui(main_widget)
@@ -530,7 +532,9 @@ class TimelapseDockWidget(QDockWidget):
             saved_project = settings.value("QgisTimelapse/project_id", "", type=str)
             if saved_project:
                 self.gee_project_edit.setText(saved_project)
-        except Exception:
+        except (
+            Exception
+        ):  # nosec B110 (best-effort QSettings read; field stays empty on failure)
             pass
         gee_layout.addRow("Project ID:", self.gee_project_edit)
 

--- a/timelapse/dialogs/update_checker.py
+++ b/timelapse/dialogs/update_checker.py
@@ -10,7 +10,7 @@ import re
 import shutil
 import tempfile
 import zipfile
-from urllib.request import urlopen, urlretrieve
+from urllib.request import urlopen
 from urllib.error import URLError, HTTPError
 
 from qgis.PyQt.QtCore import Qt, QThread, pyqtSignal
@@ -35,6 +35,48 @@ PLUGIN_PATH = "timelapse"
 METADATA_URL = f"https://raw.githubusercontent.com/{GITHUB_REPO}/{GITHUB_BRANCH}/{PLUGIN_PATH}/metadata.txt"
 ZIP_URL = f"https://github.com/{GITHUB_REPO}/archive/refs/heads/{GITHUB_BRANCH}.zip"
 
+DOWNLOAD_TIMEOUT = 30
+
+
+def _require_https(url):
+    """Reject any non-https URL before opening it.
+
+    Args:
+        url: The URL to validate.
+
+    Raises:
+        ValueError: If the URL does not use the https scheme.
+    """
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing to open non-https URL: {url}")
+
+
+def _download_to_file(url, dest_path, reporthook=None, timeout=DOWNLOAD_TIMEOUT):
+    """Download an https URL to a file with timeout and progress callback.
+
+    Args:
+        url: Source URL (must use https).
+        dest_path: Destination file path.
+        reporthook: Optional callable(block_num, block_size, total_size) for progress.
+        timeout: Socket timeout in seconds.
+    """
+    _require_https(url)
+    chunk_size = 8192
+    with urlopen(
+        url, timeout=timeout
+    ) as response:  # nosec B310 (https enforced by _require_https)
+        total_size = int(response.headers.get("Content-Length", 0))
+        block_num = 0
+        with open(dest_path, "wb") as out_file:
+            while True:
+                chunk = response.read(chunk_size)
+                if not chunk:
+                    break
+                out_file.write(chunk)
+                block_num += 1
+                if reporthook is not None:
+                    reporthook(block_num, chunk_size, total_size)
+
 
 class VersionCheckWorker(QThread):
     """Worker thread for checking the latest version from GitHub."""
@@ -45,7 +87,10 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            with urlopen(METADATA_URL, timeout=15) as response:
+            _require_https(METADATA_URL)
+            with urlopen(
+                METADATA_URL, timeout=15
+            ) as response:  # nosec B310 (https enforced by _require_https)
                 content = response.read().decode("utf-8")
 
             # Parse version from metadata
@@ -106,7 +151,7 @@ class DownloadWorker(QThread):
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            urlretrieve(ZIP_URL, zip_path, reporthook)
+            _download_to_file(ZIP_URL, zip_path, reporthook=reporthook)
 
             self.progress.emit(60, "Extracting files...")
 
@@ -232,7 +277,7 @@ class UpdateCheckerDialog(QDialog):
         header_font.setPointSize(14)
         header_font.setBold(True)
         header_label.setFont(header_font)
-        header_label.setAlignment(Qt.AlignCenter)
+        header_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header_label)
 
         # Version info group
@@ -277,7 +322,7 @@ class UpdateCheckerDialog(QDialog):
         # Progress label
         self.progress_label = QLabel("")
         self.progress_label.setVisible(False)
-        self.progress_label.setAlignment(Qt.AlignCenter)
+        self.progress_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.progress_label)
 
         # Buttons
@@ -306,7 +351,7 @@ class UpdateCheckerDialog(QDialog):
         )
         info_label.setWordWrap(True)
         info_label.setOpenExternalLinks(True)
-        info_label.setAlignment(Qt.AlignCenter)
+        info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(info_label)
 
     def check_for_updates(self):
@@ -397,11 +442,11 @@ class UpdateCheckerDialog(QDialog):
             f"This will download and install version {self.latest_version}.\n\n"
             "IMPORTANT: You will need to restart QGIS after the update completes.\n\n"
             "Do you want to continue?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
 
-        if reply != QMessageBox.Yes:
+        if reply != QMessageBox.StandardButton.Yes:
             return
 
         self.check_btn.setEnabled(False)
@@ -482,10 +527,10 @@ class UpdateCheckerDialog(QDialog):
                 self,
                 "Download in Progress",
                 "A download is in progress. Are you sure you want to cancel?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
-            if reply != QMessageBox.Yes:
+            if reply != QMessageBox.StandardButton.Yes:
                 event.ignore()
                 return
             self.download_worker.terminate()

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -1,8 +1,9 @@
 [general]
 name=Timelapse
 qgisMinimumVersion=3.28
+qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, and MODIS NDVI) using Google Earth Engine
-version=0.8.1
+version=0.9.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -32,6 +33,9 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.9.0:
+        - Compatible with QGIS 4.0 (Qt6) while keeping QGIS 3.28+ support
+        - Hardened security: timeouts on network downloads, narrower exception handlers, https-only URL guard
     0.8.1:
         - Fix issue with venv creation on Windows
     0.8.0:

--- a/timelapse/timelapse_plugin.py
+++ b/timelapse/timelapse_plugin.py
@@ -251,15 +251,16 @@ class TimelapsePlugin:
                 f"  {missing_names}\n\n"
                 f"The Timelapse plugin needs these packages to function.\n\n"
                 f"Would you like to open Settings to install them?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.Yes,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.Yes,
             )
 
-            if reply == QMessageBox.Yes:
+            if reply == QMessageBox.StandardButton.Yes:
                 self._open_settings_deps_tab()
 
-        except Exception:
-            # Don't let dependency check errors prevent other actions
+        # Reason: dependency check is advisory; a failure here must never
+        # interrupt the rest of the plugin's startup or user actions.
+        except Exception:  # nosec B110
             pass
 
     def _open_settings_deps_tab(self):
@@ -275,7 +276,9 @@ class TimelapsePlugin:
                 self._settings_dock.visibilityChanged.connect(
                     self._on_settings_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._settings_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
+                )
                 self._connect_deps_signal()
             except Exception as e:
                 QMessageBox.critical(
@@ -338,7 +341,9 @@ class TimelapsePlugin:
                 self._settings_dock.visibilityChanged.connect(
                     self._on_settings_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._settings_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
+                )
                 self._connect_deps_signal()
             except Exception as e:
                 QMessageBox.critical(
@@ -391,7 +396,7 @@ class TimelapsePlugin:
                     QgsMessageLog.logMessage(
                         f"Auto-initializing Earth Engine with project: {project_id}",
                         "Timelapse",
-                        Qgis.Info,
+                        Qgis.MessageLevel.Info,
                     )
                     initialize_ee(project=project_id)
                 except Exception as exc:
@@ -400,7 +405,7 @@ class TimelapsePlugin:
                     QgsMessageLog.logMessage(
                         f"Auto-init EE failed: {exc}",
                         "Timelapse",
-                        Qgis.Warning,
+                        Qgis.MessageLevel.Warning,
                     )
         except ImportError:
             pass
@@ -427,7 +432,9 @@ class TimelapsePlugin:
                 self._timelapse_dock.visibilityChanged.connect(
                     self._on_timelapse_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._timelapse_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._timelapse_dock
+                )
                 self._timelapse_dock.show()
                 self._timelapse_dock.raise_()
                 return
@@ -469,7 +476,9 @@ class TimelapsePlugin:
                 self._settings_dock.visibilityChanged.connect(
                     self._on_settings_visibility_changed
                 )
-                self.iface.addDockWidget(Qt.RightDockWidgetArea, self._settings_dock)
+                self.iface.addDockWidget(
+                    Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
+                )
                 self._settings_dock.show()
                 self._settings_dock.raise_()
                 self._connect_deps_signal()
@@ -505,7 +514,7 @@ class TimelapsePlugin:
             from .dialogs.about_dialog import AboutDialog
 
             dialog = AboutDialog(self.plugin_dir, self.iface.mainWindow())
-            dialog.exec_()
+            dialog.exec()
         except Exception:
             # Fallback to simple message box
             version = self._get_version()
@@ -552,7 +561,7 @@ class TimelapsePlugin:
 
         try:
             dialog = UpdateCheckerDialog(self.plugin_dir, self.iface.mainWindow())
-            dialog.exec_()
+            dialog.exec()
         except Exception as e:
             QMessageBox.critical(
                 self.iface.mainWindow(),


### PR DESCRIPTION
## Summary

- Migrates the plugin to load on both **QGIS 3.x (PyQt5)** and **QGIS 4.0 (PyQt6)** from a single codebase. PyQt5 ≥ 5.15 accepts the fully-qualified enum form, so no version branching is needed.
- Sets `qgisMaximumVersion=4.99` in `metadata.txt`, which opts the plugin in to the [QGIS 4 Ready plugin list](https://plugins.qgis.org/plugins/new_qgis_ready/). Existing 3.28+ users keep working.
- Hardens security to clear the Bandit scan that `plugins.qgis.org` runs on every upload (gate is medium/high; this PR also clears every low finding).
- Adds PyQt6 import-smoke tests and a CI workflow with `pre-commit`, `bandit`, and per-Python-version `pyqt6-smoke` jobs.

## What changed

**Qt/QGIS enum qualification** — all short-form enums replaced with fully-qualified forms that work on both Qt5 and Qt6:

| Before | After |
| --- | --- |
| `Qt.AlignCenter` | `Qt.AlignmentFlag.AlignCenter` |
| `Qt.LeftDockWidgetArea \| Qt.RightDockWidgetArea` | `Qt.DockWidgetArea.LeftDockWidgetArea \| Qt.DockWidgetArea.RightDockWidgetArea` |
| `Qt.KeepAspectRatio`, `Qt.SmoothTransformation`, `Qt.ScrollBarAlwaysOff` | fully-qualified (`AspectRatioMode`, `TransformationMode`, `ScrollBarPolicy`) |
| `QMessageBox.Yes \| QMessageBox.No` | `QMessageBox.StandardButton.Yes \| QMessageBox.StandardButton.No` |
| `Qgis.Info`, `Qgis.Warning`, `Qgis.Critical`, `Qgis.Success` | `Qgis.MessageLevel.*` |
| `dialog.exec_()` | `dialog.exec()` |

**Metadata** — `version=0.9.0`, added `qgisMaximumVersion=4.99`, kept `qgisMinimumVersion=3.28`. Changelog entry added.

**Security hardening** (clears Bandit on `plugins.qgis.org`):

- Replaced `urlretrieve(...)` (no timeout support in stdlib) with a chunked `urlopen(..., timeout=15)` helper that preserves the progress callback. New `_download_to_file()` and `_require_https()` in `update_checker.py`.
- Added timeout + https-only guard to the EE thumbnail download in `timelapse_core.py`.
- Tightened bare `except:` blocks to specific exception types in `timelapse_core.py`.
- Suppressed legitimate low-severity findings (subprocess list-form calls, OAuth2 endpoint URL, intentional best-effort cleanup paths) with `# nosec BXXX` plus a one-line rationale.

**Tests + CI** (none existed before):

- `tests/conftest.py` — stubs `qgis.PyQt.*` onto real PyQt6 modules and stubs `qgis.core/gui/utils` with auto-generated real type objects (so `pyqtSignal(QgsRectangle)` and `class X(QgsMapToolEmitPoint)` work at import time).
- `tests/test_pyqt6_imports.py` — auto-discovers the plugin package and imports every `.py` file under PyQt6.
- `.github/workflows/ci.yml` — three jobs: `pre-commit`, `bandit -r timelapse` (matches the plugins.qgis.org scan), and `pyqt6-smoke` parametrized over Python 3.10/3.11/3.12/3.13 with the Ubuntu Qt6 runtime libs apt-installed.
- Added Bandit to `.pre-commit-config.yaml` so contributors catch issues locally.

## Verification done locally

- [x] `pre-commit run --all-files` clean (includes the new Bandit hook)
- [x] `bandit -r timelapse` prints `No issues identified.` (22 findings disabled with documented `# nosec BXXX`)
- [x] `pytest tests/ -v` — all 14 plugin modules import cleanly under PyQt6
- [x] `python -m compileall timelapse` succeeds
- [x] `grep -rn '\.exec_(' timelapse/` returns nothing
- [x] No leftover short-form Qt / QMessageBox / Qgis enums

## Test plan (manual, before merge)

- [ ] Install branch into QGIS 3.28+ (Qt5). Open Timelapse dock; run NAIP/Landsat/Sentinel-2/Sentinel-1/MODIS/GOES timelapses; open Settings dock; About dialog; Update checker; trigger the dependency installer flow. Confirm dialogs, toolbar, dock placement, message-bar messages all render correctly.
- [ ] Install branch into a QGIS 4.0 nightly (Qt6). Repeat the same exercise. Pay extra attention to `QMessageBox` confirmations, dock area docking, and the EE auth dialog (`exec()` paths).

## References

- https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6
- https://plugins.qgis.org/docs/migrate-qgis4