### PR TITLE
Fix #44: open Settings → Dependencies instead of failing silently

### DIFF
--- a/tests/test_venv_manager.py
+++ b/tests/test_venv_manager.py
@@ -1,0 +1,89 @@
+"""Tests for virtual environment dependency status checks."""
+
+from timelapse.core import python_manager, venv_manager
+
+
+def _write_dist_info(site_packages, directory_name, package_name, version):
+    dist_info = site_packages / directory_name
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "\n".join(
+            [
+                "Metadata-Version: 2.1",
+                f"Name: {package_name}",
+                f"Version: {version}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_get_venv_status_accepts_pillow_import_and_lowercase_dist_info(
+    tmp_path, monkeypatch
+):
+    """Pillow installs as PIL plus lowercase pillow-*.dist-info on Unix."""
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+
+    _write_dist_info(
+        site_packages,
+        "earthengine_api-1.7.4.dist-info",
+        "earthengine-api",
+        "1.7.4",
+    )
+    _write_dist_info(site_packages, "numpy-2.3.5.dist-info", "numpy", "2.3.5")
+    _write_dist_info(site_packages, "pillow-12.1.1.dist-info", "Pillow", "12.1.1")
+    _write_dist_info(
+        site_packages,
+        "google_auth_oauthlib-1.2.3.dist-info",
+        "google-auth-oauthlib",
+        "1.2.3",
+    )
+    (site_packages / "PIL").mkdir()
+
+    monkeypatch.setattr(python_manager, "standalone_python_exists", lambda: True)
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager,
+        "get_venv_site_packages",
+        lambda venv_dir=None: str(site_packages),
+    )
+
+    assert venv_manager.get_venv_status() == (True, "Virtual environment ready")
+
+
+def test_check_dependencies_reports_versions_from_venv_site_packages(
+    tmp_path, monkeypatch
+):
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+
+    _write_dist_info(
+        site_packages,
+        "earthengine_api-1.7.4.dist-info",
+        "earthengine-api",
+        "1.7.4",
+    )
+    _write_dist_info(site_packages, "numpy-2.3.5.dist-info", "numpy", "2.3.5")
+    _write_dist_info(site_packages, "pillow-12.1.1.dist-info", "Pillow", "12.1.1")
+    _write_dist_info(
+        site_packages,
+        "google_auth_oauthlib-1.2.3.dist-info",
+        "google-auth-oauthlib",
+        "1.2.3",
+    )
+
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager,
+        "get_venv_site_packages",
+        lambda venv_dir=None: str(site_packages),
+    )
+    monkeypatch.setattr(venv_manager, "ensure_venv_packages_available", lambda: True)
+
+    all_ok, missing, installed = venv_manager.check_dependencies()
+
+    assert all_ok is True
+    assert missing == []
+    assert dict(installed)["Pillow"] == "12.1.1"

--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -10,6 +10,7 @@ import importlib
 import importlib.metadata
 import os
 import platform
+import re
 import shutil
 import subprocess  # nosec B404 (validated list-form calls only; commands are pinned, not user input)
 import sys
@@ -27,6 +28,12 @@ REQUIRED_PACKAGES = [
     ("Pillow", ""),
     ("google-auth-oauthlib", ""),
 ]
+
+PACKAGE_IMPORT_DIRS = {
+    "earthengine-api": ("ee",),
+    "Pillow": ("PIL",),
+    "google-auth-oauthlib": ("google_auth_oauthlib",),
+}
 
 
 def _log(message, level=Qgis.MessageLevel.Info):
@@ -210,6 +217,56 @@ def venv_exists(venv_dir=None):
         True if the venv Python executable exists.
     """
     return os.path.exists(get_venv_python_path(venv_dir))
+
+
+def _normalize_distribution_name(name):
+    """Normalize a Python distribution name for case-insensitive comparison."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _get_installed_version_from_site_packages(package_name, site_packages):
+    """Return an installed distribution version from a specific site-packages path."""
+    normalized_name = _normalize_distribution_name(package_name)
+    for distribution in importlib.metadata.distributions(path=[site_packages]):
+        distribution_name = distribution.metadata.get("Name")
+        if (
+            distribution_name
+            and _normalize_distribution_name(distribution_name) == normalized_name
+        ):
+            return distribution.version
+    return None
+
+
+def _package_exists_in_site_packages(package_name, site_packages):
+    """Check whether a package appears to be installed in site-packages.
+
+    Prefer distribution metadata. Fall back to import package directories for
+    packages whose distribution name differs from their import name, such as
+    Pillow -> PIL.
+    """
+    if _get_installed_version_from_site_packages(package_name, site_packages):
+        return True
+
+    import_dirs = PACKAGE_IMPORT_DIRS.get(
+        package_name, (package_name.replace("-", "_"),)
+    )
+    for import_dir in import_dirs:
+        if os.path.exists(os.path.join(site_packages, import_dir)):
+            return True
+
+    normalized_name = _normalize_distribution_name(package_name)
+    try:
+        entries = os.listdir(site_packages)
+    except OSError:
+        return False
+
+    return any(
+        entry.endswith((".dist-info", ".egg-info"))
+        and _normalize_distribution_name(entry.rsplit(".", 1)[0]).startswith(
+            f"{normalized_name}-"
+        )
+        for entry in entries
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -985,21 +1042,12 @@ def get_venv_status():
     if not venv_exists():
         return False, "Virtual environment not configured"
 
-    # Quick filesystem check for packages
     site_packages = get_venv_site_packages()
     if site_packages is None:
         return False, "Virtual environment incomplete"
 
     for package_name, _ in REQUIRED_PACKAGES:
-        pkg_dir = os.path.join(site_packages, package_name.replace("-", "_"))
-        dist_info_pattern = package_name.replace("-", "_")
-        has_pkg = os.path.exists(pkg_dir)
-        has_dist = any(
-            entry.startswith(dist_info_pattern) and entry.endswith(".dist-info")
-            for entry in os.listdir(site_packages)
-        )
-
-        if not has_pkg and not has_dist:
+        if not _package_exists_in_site_packages(package_name, site_packages):
             return False, f"Package {package_name} not found in venv"
 
     return True, "Virtual environment ready"
@@ -1008,8 +1056,8 @@ def get_venv_status():
 def check_dependencies():
     """Check if all required packages are installed and importable.
 
-    Attempts to use importlib.metadata after ensuring venv packages
-    are on sys.path. This is a lightweight check suitable for UI display.
+    Reads package metadata from the plugin venv site-packages path. This is a
+    lightweight check suitable for UI display.
 
     Returns:
         A tuple of (all_ok, missing, installed) where:
@@ -1017,16 +1065,22 @@ def check_dependencies():
             missing: List of (package_name, version_spec) for missing packages.
             installed: List of (package_name, version_string) for installed packages.
     """
+    site_packages = get_venv_site_packages()
+    if site_packages is None:
+        return False, REQUIRED_PACKAGES.copy(), []
+
     ensure_venv_packages_available()
 
     missing = []
     installed = []
 
     for package_name, version_spec in REQUIRED_PACKAGES:
-        try:
-            version = importlib.metadata.version(package_name)
+        version = _get_installed_version_from_site_packages(package_name, site_packages)
+        if version:
             installed.append((package_name, version))
-        except importlib.metadata.PackageNotFoundError:
+        elif _package_exists_in_site_packages(package_name, site_packages):
+            installed.append((package_name, "unknown"))
+        else:
             missing.append((package_name, version_spec))
 
     all_ok = len(missing) == 0

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -3,7 +3,7 @@ name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, and MODIS NDVI) using Google Earth Engine
-version=0.9.0
+version=0.10.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -33,6 +33,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.10.0:
+        - Fix dependency status mismatch for Pillow/PIL in the plugin virtual environment
     0.9.0:
         - Compatible with QGIS 4.0 (Qt6) while keeping QGIS 3.28+ support
         - Hardened security: timeouts on network downloads, narrower exception handlers, https-only URL guard
@@ -66,5 +68,4 @@ changelog=
         - Area of interest from map extent or vector layer
         - GIF and MP4 output formats
         - Customizable text overlays and progress bars
-
 

--- a/timelapse/timelapse_plugin.py
+++ b/timelapse/timelapse_plugin.py
@@ -8,6 +8,7 @@ integration, menu items, toolbar buttons, and dockable panels.
 import os
 import re
 
+from qgis.core import Qgis, QgsMessageLog
 from qgis.PyQt.QtCore import Qt, QSettings, QTranslator, QCoreApplication
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QMenu, QToolBar, QMessageBox
@@ -211,8 +212,9 @@ class TimelapsePlugin:
     def _ensure_deps(self) -> bool:
         """Check if dependencies are installed and loaded.
 
-        Returns True if deps are ready. If not, shows a non-blocking
-        warning and offers to open Settings -> Dependencies tab.
+        Returns True if deps are ready. If not, opens Settings on the
+        Dependencies tab and shows a message bar so the user is never
+        left wondering why "Create Timelapse" did nothing.
 
         Returns:
             True if dependencies are ready and loaded, False otherwise.
@@ -223,45 +225,49 @@ class TimelapsePlugin:
         from .core.venv_manager import ensure_venv_packages_available, get_venv_status
 
         is_ready, status_msg = get_venv_status()
+        QgsMessageLog.logMessage(
+            f"_ensure_deps: get_venv_status -> ({is_ready}, {status_msg!r})",
+            "Timelapse",
+            Qgis.MessageLevel.Info,
+        )
 
-        if is_ready:
-            if ensure_venv_packages_available():
-                self._deps_ready = True
-                self._post_deps_init()
-                return True
+        if is_ready and ensure_venv_packages_available():
+            self._deps_ready = True
+            self._post_deps_init()
+            return True
 
-        # Dependencies not ready -- show non-blocking warning
-        self._check_dependencies_on_open()
+        self._prompt_install_dependencies(status_msg)
         return False
 
-    def _check_dependencies_on_open(self):
-        """Check if dependencies are installed and prompt if missing."""
+    def _prompt_install_dependencies(self, status_msg):
+        """Route the user to Settings -> Dependencies when deps are missing.
+
+        Always visible: pushes a warning to the QGIS message bar, logs the
+        same message to the Timelapse log channel, opens the Settings dock
+        on the Dependencies tab, and un-checks the Timelapse toolbar action.
+
+        Args:
+            status_msg: The status string returned by get_venv_status().
+        """
+        message = (
+            f"Dependencies not installed ({status_msg}). "
+            f"Opening Settings → Dependencies."
+        )
+        QgsMessageLog.logMessage(message, "Timelapse", Qgis.MessageLevel.Warning)
         try:
-            from .core.venv_manager import check_dependencies
-
-            all_ok, missing, _installed = check_dependencies()
-            if all_ok:
-                return
-
-            missing_names = ", ".join(name for name, _ in missing)
-            reply = QMessageBox.warning(
-                self.iface.mainWindow(),
-                "Missing Dependencies",
-                f"The following required packages are not installed:\n\n"
-                f"  {missing_names}\n\n"
-                f"The Timelapse plugin needs these packages to function.\n\n"
-                f"Would you like to open Settings to install them?",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                QMessageBox.StandardButton.Yes,
+            self.iface.messageBar().pushWarning("Timelapse", message)
+        except Exception as exc:
+            # Message bar is best-effort UX; do not block the Settings open path.
+            QgsMessageLog.logMessage(
+                f"messageBar().pushWarning failed: {exc}",
+                "Timelapse",
+                Qgis.MessageLevel.Warning,
             )
 
-            if reply == QMessageBox.StandardButton.Yes:
-                self._open_settings_deps_tab()
+        if hasattr(self, "timelapse_action") and self.timelapse_action is not None:
+            self.timelapse_action.setChecked(False)
 
-        # Reason: dependency check is advisory; a failure here must never
-        # interrupt the rest of the plugin's startup or user actions.
-        except Exception:  # nosec B110
-            pass
+        self._open_settings_deps_tab()
 
     def _open_settings_deps_tab(self):
         """Open the Settings dock and switch to the Dependencies tab."""


### PR DESCRIPTION
## Summary
- Closes #44. Clicking **Create Timelapse** without dependencies installed now opens **Settings → Dependencies** with a clear yellow message bar, instead of silently doing nothing.
- Replaced the silent failure path in `_ensure_deps()` with a single `_prompt_install_dependencies()` helper that always: (a) pushes a QGIS message-bar warning, (b) logs the venv status to the *Timelapse* log channel, (c) opens Settings on the Dependencies tab, (d) un-checks the toolbar action.
- Removed the `except Exception: pass` block in the old `_check_dependencies_on_open()` that swallowed any error during dep checking.

### Root cause
`_ensure_deps()` called `_check_dependencies_on_open()`, which used `importlib.metadata.version()` to look up the four required packages. On systems where QGIS or a side-loaded Python (pixi, system pip, etc.) had them on `sys.path`, `all_ok=True` and the method returned without showing UI — even though the plugin's standalone Python venv was never created. `_ensure_deps()` then returned `False`, the toolbar button un-checked itself, and the user saw nothing.

## Test plan
- [x] `pre-commit run --all-files` clean
- [x] `pytest tests/` (PyQt6 import-smoke suite) — 14 passed
- [ ] Manual on a fresh `~/.qgis_timelapse/` (deps never installed): click **Create Timelapse** → Settings dock opens on the Dependencies tab + yellow message bar appears
- [ ] Manual happy path: install deps, click **Create Timelapse** → timelapse dock opens as before