### PR TITLE
Fix #49: surface real Earth Engine init errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,15 +358,14 @@ The plugin includes a built-in update checker:
 
 **"Failed to initialize Google Earth Engine"**
 
-- Ensure you have an active Earth Engine account
-- Log in to your Earth Engine account at <https://code.earthengine.google.com> to get your Project ID
-- Open the QGIS Python Console (QGIS -> Plugins -> Python Console) and run the following Python code to authenticate and initialize Earth Engine. Make sure to replace `your-ee-project` with your actual Earth Engine Project ID.
-
-```python
-import ee
-ee.Authenticate()
-ee.Initialize(project="your-ee-project")
-```
+- Ensure you have an active Earth Engine account.
+- Log in to your Earth Engine account at <https://code.earthengine.google.com> to get your Project ID.
+- The plugin installs its dependencies into an isolated virtual environment at `~/.qgis_timelapse` (Linux/macOS) or `%USERPROFILE%\.qgis_timelapse` (Windows), so running `earthengine authenticate` from a different Python on your system may not be enough. Authenticate from inside the plugin instead:
+    1. Open the **Timelapse Settings** panel (Plugins → Timelapse → Settings).
+    2. Switch to the **Earth Engine** tab.
+    3. Enter your Project ID, then click **Authenticate (opens browser)** and complete the sign-in.
+    4. Click **Initialize Earth Engine**. A successful init now also runs a small test request, so any project-level issues (Earth Engine API not enabled, missing scopes, unregistered account) are reported here rather than later when you start a run.
+- If a run still fails, the error message in the timelapse log now includes the underlying exception text. That message is your fastest path to a fix.
 
 ![](https://github.com/user-attachments/assets/a7321180-1261-4c82-b545-9dbe676a864c)
 

--- a/tests/test_initialize_ee_errors.py
+++ b/tests/test_initialize_ee_errors.py
@@ -1,0 +1,145 @@
+"""Tests for ``timelapse_core.initialize_ee`` error surfacing.
+
+Issue #49: when initialization fails the plugin used to raise the
+generic message "Please authenticate first" with no detail. These tests
+pin the new contract: the failure cause is recorded into
+``get_last_init_error()`` and ``ee.Authenticate()`` is *not* invoked
+silently from inside ``initialize_ee``.
+"""
+
+import os
+import types
+
+import pytest
+
+from timelapse.core import timelapse_core
+
+
+@pytest.fixture(autouse=True)
+def _reset_core_state(monkeypatch):
+    """Wipe the module-level cache so tests do not leak into each other."""
+    monkeypatch.setattr(timelapse_core, "_ee_initialized", False)
+    monkeypatch.setattr(timelapse_core, "_last_init_error", None)
+    # Clear EE_PROJECT_ID so tests don't pick up the dev environment value.
+    monkeypatch.delenv("EE_PROJECT_ID", raising=False)
+
+
+def _install_fake_ee(monkeypatch, *, initialize, authenticate=None):
+    """Install a fake ``ee`` module on ``timelapse_core`` for the test.
+
+    Args:
+        monkeypatch: pytest's ``monkeypatch`` fixture.
+        initialize: Callable substituted for ``ee.Initialize``.
+        authenticate: Callable substituted for ``ee.Authenticate``. Defaults
+            to one that fails the test if invoked, so we can assert it is
+            never called from inside ``initialize_ee``.
+    """
+    if authenticate is None:
+
+        def authenticate(*args, **kwargs):
+            raise AssertionError(
+                "initialize_ee must not call ee.Authenticate(); "
+                "auth is the Settings dock's job"
+            )
+
+    fake_ee = types.SimpleNamespace(
+        Initialize=initialize,
+        Authenticate=authenticate,
+    )
+    monkeypatch.setattr(timelapse_core, "ee", fake_ee)
+
+
+def test_missing_dep_sets_descriptive_error(monkeypatch):
+    """When ``ee`` is None the error names earthengine-api, not auth."""
+    monkeypatch.setattr(timelapse_core, "ee", None)
+
+    assert timelapse_core.initialize_ee(project="proj") is False
+
+    err = timelapse_core.get_last_init_error()
+    assert err is not None
+    assert "earthengine-api" in err
+    assert "Settings" in err and "Dependencies" in err
+
+
+def test_initialize_failure_captures_real_exception(monkeypatch, tmp_path):
+    """The exception from ``ee.Initialize`` is preserved verbatim."""
+    # Avoid hitting a real ~/.config/earthengine/credentials on the test box.
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda p: str(tmp_path / "no-such-credentials") if "earthengine" in p else p,
+    )
+
+    def boom(**kwargs):
+        raise RuntimeError("project does not have Earth Engine API enabled")
+
+    _install_fake_ee(monkeypatch, initialize=boom)
+
+    assert timelapse_core.initialize_ee(project="my-proj") is False
+
+    err = timelapse_core.get_last_init_error()
+    assert err is not None
+    # The real exception text must be in the surfaced message; the user
+    # cannot diagnose without it.
+    assert "project does not have Earth Engine API enabled" in err
+    assert "my-proj" in err
+    # It should also point them at the Settings dock.
+    assert "Settings" in err and "Earth Engine" in err
+
+
+def test_initialize_does_not_call_authenticate_on_failure(monkeypatch, tmp_path):
+    """Regression: ``ee.Authenticate()`` must never run from a worker thread.
+
+    The fake ``ee.Authenticate`` raises if called, and the fake ``ee.Initialize``
+    raises so the old fallback path would have triggered.
+    """
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda p: str(tmp_path / "no-such-credentials") if "earthengine" in p else p,
+    )
+
+    def init_boom(**kwargs):
+        raise RuntimeError("init failed")
+
+    # _install_fake_ee installs an Authenticate that fails the test if hit.
+    _install_fake_ee(monkeypatch, initialize=init_boom)
+
+    # Should return False without invoking ee.Authenticate()
+    # (the AssertionError from authenticate would propagate out otherwise).
+    assert timelapse_core.initialize_ee(project="my-proj") is False
+
+
+def test_successful_init_clears_error(monkeypatch, tmp_path):
+    """A successful init resets ``get_last_init_error`` to None."""
+    # Pre-populate an error string to prove it gets cleared.
+    monkeypatch.setattr(timelapse_core, "_last_init_error", "stale error")
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda p: str(tmp_path / "no-such-credentials") if "earthengine" in p else p,
+    )
+
+    def ok(**kwargs):
+        return None
+
+    _install_fake_ee(monkeypatch, initialize=ok)
+
+    assert timelapse_core.initialize_ee(project="my-proj") is True
+    assert timelapse_core.get_last_init_error() is None
+    assert timelapse_core.is_ee_initialized() is True
+
+
+def test_mark_ee_initialized_helper(monkeypatch):
+    """The Settings dock helper toggles the flag and clears the error."""
+    monkeypatch.setattr(timelapse_core, "_last_init_error", "stale error")
+    monkeypatch.setattr(timelapse_core, "_ee_initialized", False)
+
+    timelapse_core.mark_ee_initialized(True)
+
+    assert timelapse_core.is_ee_initialized() is True
+    assert timelapse_core.get_last_init_error() is None
+
+    timelapse_core.mark_ee_initialized(False)
+
+    assert timelapse_core.is_ee_initialized() is False

--- a/timelapse/core/timelapse_core.py
+++ b/timelapse/core/timelapse_core.py
@@ -94,12 +94,24 @@ def _load_ee_credentials():
     ``ee``'s built-in auto-discovery inside the QGIS process, where
     bundled library versions may conflict with the venv packages.
 
+    Side effect:
+        On failure, records a description into the module-level
+        ``_last_init_error`` so callers can surface the real cause
+        instead of a generic "auth failed" message.
+
     Returns:
         A ``google.oauth2.credentials.Credentials`` instance, or *None*
         if the file does not exist or cannot be parsed.
     """
+    global _last_init_error
+
     cred_path = os.path.expanduser("~/.config/earthengine/credentials")
     if not os.path.exists(cred_path):
+        _last_init_error = (
+            f"Earth Engine credentials file not found at {cred_path}. "
+            "Open Settings → Earth Engine and click "
+            "'Authenticate (opens browser)'."
+        )
         return None
 
     try:
@@ -108,6 +120,10 @@ def _load_ee_credentials():
 
         refresh_token = data.get("refresh_token")
         if not refresh_token:
+            _last_init_error = (
+                f"Credentials file at {cred_path} is missing a refresh_token. "
+                "Re-authenticate via Settings → Earth Engine."
+            )
             return None
 
         from google.oauth2.credentials import Credentials
@@ -119,7 +135,13 @@ def _load_ee_credentials():
             client_id=data.get("client_id"),
             client_secret=data.get("client_secret"),
         )
-    except Exception:
+    except Exception as e:
+        _last_init_error = (
+            f"Failed to load credentials from {cred_path}: {e!r}. "
+            "If this mentions 'google.oauth2', the plugin's venv "
+            "dependencies may not be on sys.path; reopen QGIS or "
+            "reinstall via Settings → Dependencies."
+        )
         return None
 
 
@@ -135,6 +157,11 @@ def get_ee_project() -> Optional[str]:
 # Global flag to track if EE has been initialized
 _ee_initialized = False
 
+# Description of the most recent initialize_ee() failure, surfaced by
+# get_last_init_error() so the UI can show a real diagnostic instead
+# of a generic "please authenticate" message.
+_last_init_error: Optional[str] = None
+
 
 def is_ee_initialized() -> bool:
     """Check if Earth Engine has been initialized.
@@ -146,8 +173,50 @@ def is_ee_initialized() -> bool:
     return _ee_initialized
 
 
+def mark_ee_initialized(value: bool = True) -> None:
+    """Set the cached "EE has been initialized" flag.
+
+    The Settings dock initializes ``ee`` directly (so it can use a
+    service-account credentials file the core's own loader does not
+    handle). Without this, the worker thread would re-run
+    :func:`initialize_ee` and clobber the dialog's state. Callers should
+    invoke this after a successful direct ``ee.Initialize()`` so
+    :func:`is_ee_initialized` reflects reality.
+
+    Args:
+        value: New value for the flag. Passing ``True`` also clears
+            ``_last_init_error``.
+    """
+    global _ee_initialized, _last_init_error
+    _ee_initialized = value
+    if value:
+        _last_init_error = None
+
+
+def get_last_init_error() -> Optional[str]:
+    """Return the most recent ``initialize_ee()`` failure description.
+
+    The string is set whenever ``initialize_ee()`` returns ``False`` and
+    cleared on a successful initialization. Use this to surface the
+    actual root cause to the user instead of a hard-coded generic
+    message.
+
+    Returns:
+        A human-readable description of the last failure, or ``None`` if
+        the most recent ``initialize_ee()`` call succeeded (or has not
+        been called).
+    """
+    return _last_init_error
+
+
 def initialize_ee(project: str = None, force: bool = False) -> bool:
     """Initialize Google Earth Engine.
+
+    On failure, records a description of the cause into the module-level
+    ``_last_init_error`` (retrievable via :func:`get_last_init_error`).
+    Does **not** call ``ee.Authenticate()`` itself; authentication is
+    driven by the Settings dock, which runs it in a dedicated worker so
+    the timelapse worker thread never blocks on a browser flow.
 
     Args:
         project: GEE project ID. If None, reads from QSettings then
@@ -157,13 +226,18 @@ def initialize_ee(project: str = None, force: bool = False) -> bool:
     Returns:
         True if initialization successful, False otherwise.
     """
-    global _ee_initialized
+    global _ee_initialized, _last_init_error
 
     if ee is None:
+        _last_init_error = (
+            "earthengine-api is not loaded. Open Settings → Dependencies "
+            "and click Install, then restart QGIS if prompted."
+        )
         return False
 
     # Skip if already initialized (unless forced)
     if _ee_initialized and not force:
+        _last_init_error = None
         return True
 
     # Use provided project or fall back to QSettings / env variable
@@ -182,7 +256,8 @@ def initialize_ee(project: str = None, force: bool = False) -> bool:
             project = get_ee_project()
 
     # Load credentials from disk (more reliable than ee's auto-discovery
-    # inside QGIS due to bundled library version conflicts)
+    # inside QGIS due to bundled library version conflicts).
+    # _load_ee_credentials() sets _last_init_error itself on failure.
     credentials = _load_ee_credentials()
 
     try:
@@ -191,18 +266,16 @@ def initialize_ee(project: str = None, force: bool = False) -> bool:
         else:
             ee.Initialize(credentials=credentials)
         _ee_initialized = True
+        _last_init_error = None
         return True
-    except Exception:
-        try:
-            ee.Authenticate()
-            if project:
-                ee.Initialize(credentials=credentials, project=project)
-            else:
-                ee.Initialize(credentials=credentials)
-            _ee_initialized = True
-            return True
-        except Exception:
-            return False
+    except Exception as e:
+        project_desc = f"project={project!r}" if project else "no project"
+        _last_init_error = (
+            f"ee.Initialize({project_desc}) failed: {e!r}. "
+            "Open Settings → Earth Engine, click 'Initialize Earth Engine' "
+            "to retest, then 'Authenticate (opens browser)' if needed."
+        )
+        return False
 
 
 def try_auto_initialize_ee() -> bool:

--- a/timelapse/dialogs/settings_dock.py
+++ b/timelapse/dialogs/settings_dock.py
@@ -401,13 +401,6 @@ class SettingsDockWidget(QDockWidget):
                 )
 
             ee.Initialize(credentials=credentials, project=project)
-
-            self.ee_status_label.setText("Status: Initialized")
-            self.ee_status_label.setStyleSheet("color: green;")
-            self.iface.messageBar().pushSuccess(
-                "Timelapse", "Earth Engine initialized successfully!"
-            )
-
         except Exception as e:
             self.ee_status_label.setText("Status: Error")
             self.ee_status_label.setStyleSheet("color: red;")
@@ -416,6 +409,40 @@ class SettingsDockWidget(QDockWidget):
                 "Initialization Error",
                 f"Failed to initialize Earth Engine:\n\n{str(e)}",
             )
+            return
+
+        # Verify the connection with a tiny round-trip. ee.Initialize() is
+        # often happy even when the project lacks the Earth Engine API or
+        # the credentials are missing scopes; the failure only shows up
+        # on the first real call. Catch that here so the user learns now,
+        # not when they hit "Create Timelapse".
+        try:
+            ee.Number(1).getInfo()
+        except Exception as e:
+            self.ee_status_label.setText("Status: Error")
+            self.ee_status_label.setStyleSheet("color: red;")
+            QMessageBox.critical(
+                self,
+                "Earth Engine Verification Failed",
+                "Initialize succeeded but a test request failed:\n\n"
+                f"{str(e)}\n\n"
+                "Common causes: the Earth Engine API is not enabled for "
+                f"project '{project}', the account is not registered, or "
+                "the credentials are missing the required scopes.",
+            )
+            return
+
+        # Keep timelapse_core's cached flag in sync so the worker thread
+        # does not re-run initialize_ee() and clobber this dialog's state.
+        from ..core import timelapse_core
+
+        timelapse_core.mark_ee_initialized(True)
+
+        self.ee_status_label.setText("Status: Initialized & verified")
+        self.ee_status_label.setStyleSheet("color: green; font-weight: bold;")
+        self.iface.messageBar().pushSuccess(
+            "Timelapse", "Earth Engine initialized successfully!"
+        )
 
     def _authenticate_ee(self):
         """Start Earth Engine authentication in the background."""

--- a/timelapse/dialogs/timelapse_dock.py
+++ b/timelapse/dialogs/timelapse_dock.py
@@ -59,6 +59,9 @@ class TimelapseWorker(QThread):
     progress = pyqtSignal(str)
     finished = pyqtSignal(str, dict)  # path, params (including bbox)
     error = pyqtSignal(str)
+    # Emitted after `error` when the failure is an EE init/auth problem
+    # the user can fix by opening Settings → Earth Engine.
+    request_open_ee_settings = pyqtSignal()
 
     def __init__(self, params):
         super().__init__()
@@ -88,9 +91,13 @@ class TimelapseWorker(QThread):
                         return
 
                 if not timelapse_core.initialize_ee(project_id):
-                    self.error.emit(
-                        "Failed to initialize Google Earth Engine. Please authenticate first."
+                    detail = timelapse_core.get_last_init_error() or (
+                        "Earth Engine initialization failed for an unknown " "reason."
                     )
+                    self.error.emit(
+                        "Failed to initialize Google Earth Engine.\n\n" f"{detail}"
+                    )
+                    self.request_open_ee_settings.emit()
                     return
 
             self.progress.emit(f"Creating {imagery_type} timelapse...")
@@ -312,6 +319,10 @@ class TimelapseDockWidget(QDockWidget):
     """Dockable widget for timelapse configuration."""
 
     closed = pyqtSignal()
+    # Re-emitted from the worker so the plugin can open the Settings
+    # dock on the Earth Engine tab when init/auth is the cause of a
+    # failed run.
+    request_open_ee_settings = pyqtSignal()
 
     def __init__(self, iface, parent=None):
         super().__init__("Timelapse Animation Creator", parent)
@@ -1463,6 +1474,7 @@ class TimelapseDockWidget(QDockWidget):
         self.worker.progress.connect(self.log)
         self.worker.finished.connect(self.on_timelapse_finished)
         self.worker.error.connect(self.on_timelapse_error)
+        self.worker.request_open_ee_settings.connect(self.request_open_ee_settings)
 
         self.run_button.setEnabled(False)
         self.progress_bar.setRange(0, 100)

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -3,7 +3,7 @@ name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, and MODIS NDVI) using Google Earth Engine
-version=0.10.1
+version=0.10.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -33,6 +33,10 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.10.2:
+        - Surface real Earth Engine init errors instead of "please authenticate first" (#49)
+        - Add round-trip verification to Settings -> Earth Engine -> Initialize button
+        - Auto-open Settings on the Earth Engine tab when a run fails on init
     0.10.1:
         - Fix dependency installer Python detection for macOS QGIS app bundles
     0.10.0:

--- a/timelapse/timelapse_plugin.py
+++ b/timelapse/timelapse_plugin.py
@@ -438,6 +438,9 @@ class TimelapsePlugin:
                 self._timelapse_dock.visibilityChanged.connect(
                     self._on_timelapse_visibility_changed
                 )
+                self._timelapse_dock.request_open_ee_settings.connect(
+                    self._show_settings_ee_tab
+                )
                 self.iface.addDockWidget(
                     Qt.DockWidgetArea.RightDockWidgetArea, self._timelapse_dock
                 )

--- a/timelapse/timelapse_plugin.py
+++ b/timelapse/timelapse_plugin.py
@@ -358,15 +358,15 @@ class TimelapsePlugin:
                     f"Failed to create Settings panel:\n{str(e)}",
                 )
                 return
-        else:
-            self._settings_dock.show()
-            self._settings_dock.raise_()
-        if self._settings_dock is not None:
-            self._settings_dock.show_ee_tab()
-            self.iface.messageBar().pushInfo(
-                "Timelapse",
-                "Please enter your Google Cloud project ID and click Save Settings.",
-            )
+
+        self._settings_dock.show()
+        self._settings_dock.raise_()
+        self.settings_action.setChecked(True)
+        self._settings_dock.show_ee_tab()
+        self.iface.messageBar().pushInfo(
+            "Timelapse",
+            "Please enter your Google Cloud project ID and click Save Settings.",
+        )
 
     def _post_deps_init(self):
         """One-time initialization after dependencies are confirmed ready."""


### PR DESCRIPTION
## Summary
- Issue [#49](https://github.com/opengeos/qgis-timelapse-plugin/issues/49) reported that the plugin always shows "Failed to initialize Google Earth Engine. Please authenticate first." even when the user has a valid `~/.config/earthengine/credentials`. The real `ee.Initialize` exception was being swallowed, so users had no way to diagnose the actual failure (project not registered, EE API not enabled, credentials in wrong Python env, missing scopes, etc.).
- The timelapse worker thread also silently called `ee.Authenticate()` on first init failure, which would launch a browser flow from inside a background `QThread` and block the run for up to 5 minutes — wrong place for that behavior.
- The Settings dock's "Initialize Earth Engine" button reported success on `ee.Initialize()` returning, even when the project lacked the EE API; users only learned about it later when starting a run.

## Changes
- `timelapse_core.py`: new `get_last_init_error()` accessor; `initialize_ee()` records a precise message (deps missing / credentials missing / `ee.Initialize` exception text) and no longer calls `ee.Authenticate()` itself. Added `mark_ee_initialized()` so the Settings dock can keep the cached flag in sync after its own direct init.
- `timelapse_dock.py` (`TimelapseWorker`): includes the real exception in the failure message and emits a new `request_open_ee_settings` signal so the plugin can pop the Settings dock open on the Earth Engine tab automatically — same UX as the deps-missing path from #46.
- `settings_dock.py`: after `ee.Initialize()` succeeds, runs a `ee.Number(1).getInfo()` round-trip and surfaces the exception in `QMessageBox` if it fails, so common project/scope issues are caught at the Settings step.
- `timelapse_plugin.py`: wires the new signal to the existing `_show_settings_ee_tab()`.
- `README.md`: updates the troubleshooting section to point users at Settings → Earth Engine for in-plugin authentication and removes the now-misleading "run `ee.Authenticate()` from the QGIS Python Console" snippet (the plugin uses an isolated venv).
- `tests/test_initialize_ee_errors.py`: 5 new pytest tests covering the new error contract; the full suite is 24 passing.

## Test plan
- [x] `pytest tests/` — 24 passed (5 new + 19 existing).
- [x] `pre-commit run --all-files` — clean.
- [ ] Manual smoke in QGIS 3.x: with creds removed, "Create Timelapse" now shows the real `ee.Initialize` exception text and the Settings dock auto-opens on the Earth Engine tab.
- [ ] Manual smoke in QGIS 3.x: in Settings → Earth Engine with a bogus project ID, "Initialize Earth Engine" shows the real exception (no more silent "Initialized" while the project lacks the EE API).