### PR TITLE
Fix #49: trust ee.Initialize for credential discovery

### DIFF
--- a/tests/test_initialize_ee_errors.py
+++ b/tests/test_initialize_ee_errors.py
@@ -130,6 +130,38 @@ def test_successful_init_clears_error(monkeypatch, tmp_path):
     assert timelapse_core.is_ee_initialized() is True
 
 
+def test_initialize_does_not_pass_credentials_kwarg(monkeypatch, tmp_path):
+    """Regression for issue #49 round 2.
+
+    Building a ``google.oauth2`` ``Credentials`` object from the EE
+    credentials file passed ``client_id=None``/``client_secret=None``
+    when those fields were absent (modern ``ee.Authenticate()`` files
+    only contain ``refresh_token``), causing ``RefreshError: The
+    credentials do not contain the necessary fields``. Pinning the
+    contract: ``ee.Initialize`` is called WITHOUT a ``credentials`` kwarg
+    so ee's own discovery path runs.
+    """
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda p: str(tmp_path / "creds") if "earthengine" in p else p,
+    )
+
+    received_kwargs: dict = {}
+
+    def init_recording(**kwargs):
+        received_kwargs.update(kwargs)
+
+    _install_fake_ee(monkeypatch, initialize=init_recording)
+
+    assert timelapse_core.initialize_ee(project="my-proj") is True
+    assert "credentials" not in received_kwargs, (
+        "initialize_ee must not pass a manually built credentials object; "
+        "ee.Initialize handles credential discovery itself."
+    )
+    assert received_kwargs.get("project") == "my-proj"
+
+
 def test_mark_ee_initialized_helper(monkeypatch):
     """The Settings dock helper toggles the flag and clears the error."""
     monkeypatch.setattr(timelapse_core, "_last_init_error", "stale error")

--- a/timelapse/core/timelapse_core.py
+++ b/timelapse/core/timelapse_core.py
@@ -85,64 +85,17 @@ def reload_dependencies() -> Dict[str, bool]:
     return check_dependencies()
 
 
-def _load_ee_credentials():
-    """Load Earth Engine OAuth2 credentials from the credentials file.
-
-    Reads ``~/.config/earthengine/credentials`` and builds a
-    ``google.oauth2.credentials.Credentials`` object that can be passed
-    to ``ee.Initialize()``.  This is more reliable than relying on
-    ``ee``'s built-in auto-discovery inside the QGIS process, where
-    bundled library versions may conflict with the venv packages.
-
-    Side effect:
-        On failure, records a description into the module-level
-        ``_last_init_error`` so callers can surface the real cause
-        instead of a generic "auth failed" message.
-
-    Returns:
-        A ``google.oauth2.credentials.Credentials`` instance, or *None*
-        if the file does not exist or cannot be parsed.
-    """
-    global _last_init_error
-
-    cred_path = os.path.expanduser("~/.config/earthengine/credentials")
-    if not os.path.exists(cred_path):
-        _last_init_error = (
-            f"Earth Engine credentials file not found at {cred_path}. "
-            "Open Settings → Earth Engine and click "
-            "'Authenticate (opens browser)'."
-        )
-        return None
-
-    try:
-        with open(cred_path) as f:
-            data = json.load(f)
-
-        refresh_token = data.get("refresh_token")
-        if not refresh_token:
-            _last_init_error = (
-                f"Credentials file at {cred_path} is missing a refresh_token. "
-                "Re-authenticate via Settings → Earth Engine."
-            )
-            return None
-
-        from google.oauth2.credentials import Credentials
-
-        return Credentials(
-            token=None,
-            refresh_token=refresh_token,
-            token_uri="https://oauth2.googleapis.com/token",  # nosec B106 (public Google OAuth2 endpoint, not a secret)
-            client_id=data.get("client_id"),
-            client_secret=data.get("client_secret"),
-        )
-    except Exception as e:
-        _last_init_error = (
-            f"Failed to load credentials from {cred_path}: {e!r}. "
-            "If this mentions 'google.oauth2', the plugin's venv "
-            "dependencies may not be on sys.path; reopen QGIS or "
-            "reinstall via Settings → Dependencies."
-        )
-        return None
+# NOTE: We deliberately do not build a ``google.oauth2.credentials.Credentials``
+# object ourselves. An earlier version of this module did so to "avoid
+# bundled library version conflicts inside QGIS", but the resulting
+# Credentials object passed ``client_id=None``/``client_secret=None`` when
+# the credentials file omitted them — and modern ``ee.Authenticate()``
+# writes files with only a ``refresh_token`` because ee supplies its own
+# client_id/client_secret constants at refresh time. That mismatch surfaced
+# as ``RefreshError: The credentials do not contain the necessary fields``
+# on issue #49. Letting ``ee.Initialize()`` handle credential discovery
+# itself avoids the issue entirely and matches what every other ee client
+# does.
 
 
 def get_ee_project() -> Optional[str]:
@@ -255,16 +208,11 @@ def initialize_ee(project: str = None, force: bool = False) -> bool:
         if not project:
             project = get_ee_project()
 
-    # Load credentials from disk (more reliable than ee's auto-discovery
-    # inside QGIS due to bundled library version conflicts).
-    # _load_ee_credentials() sets _last_init_error itself on failure.
-    credentials = _load_ee_credentials()
-
     try:
         if project:
-            ee.Initialize(credentials=credentials, project=project)
+            ee.Initialize(project=project)
         else:
-            ee.Initialize(credentials=credentials)
+            ee.Initialize()
         _ee_initialized = True
         _last_init_error = None
         return True
@@ -313,10 +261,8 @@ def try_auto_initialize_ee() -> bool:
     if not project:
         return False
 
-    credentials = _load_ee_credentials()
-
     try:
-        ee.Initialize(credentials=credentials, project=project)
+        ee.Initialize(project=project)
         _ee_initialized = True
         return True
     except Exception:

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -3,7 +3,7 @@ name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, and MODIS NDVI) using Google Earth Engine
-version=0.10.2
+version=0.10.3
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -33,6 +33,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.10.3:
+        - Fix RefreshError on Earth Engine init when the credentials file omits client_id/client_secret (#49); rely on ee.Initialize for credential discovery
     0.10.2:
         - Surface real Earth Engine init errors instead of "please authenticate first" (#49)
         - Add round-trip verification to Settings -> Earth Engine -> Initialize button


### PR DESCRIPTION
## Summary
- Round 2 of #49. The first fix (#50) made the failure self-diagnosable, which immediately surfaced the real cause: ``_load_ee_credentials`` was passing ``client_id=None``/``client_secret=None`` to ``google.oauth2.credentials.Credentials`` when those fields were missing from ``~/.config/earthengine/credentials``. Modern ``ee.Authenticate()`` writes credentials with only ``refresh_token`` (ee injects its own well-known ``client_id``/``client_secret`` constants at refresh time), producing ``RefreshError: The credentials do not contain the necessary fields``.
- Drop the manual builder entirely and let ``ee.Initialize`` discover credentials itself, matching what every other ee client does. The original "bundled library version conflicts" justification for the workaround does not hold up — the venv's ``google.oauth2`` is on ``sys.path`` first, and the ``ee`` import already comes from the same venv.

## Changes
- ``timelapse/core/timelapse_core.py``: remove ``_load_ee_credentials``; ``initialize_ee`` and ``try_auto_initialize_ee`` now call ``ee.Initialize(project=project)`` without a ``credentials`` kwarg. Comment block records why so this does not get re-introduced.
- ``tests/test_initialize_ee_errors.py``: add ``test_initialize_does_not_pass_credentials_kwarg`` pinning the new contract — ``ee.Initialize`` must not receive a ``credentials`` kwarg.
- ``timelapse/metadata.txt``: bump to ``0.10.3`` with a changelog entry.

## Test plan
- [x] ``pytest tests/`` — 25 passed (1 new + 24 existing).
- [x] ``pre-commit run --files <changed>`` — clean.
- [ ] Manual smoke (issue author): create a timelapse on Windows with a credentials file written by ``ee.Authenticate()`` that lacks ``client_id``/``client_secret``. Expect: init succeeds; the run proceeds.