### PR TITLE
Fix #49: force auth_mode='localhost' and log full auth traceback

### DIFF
--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -1451,12 +1451,17 @@ def authenticate_ee(
     env = _get_clean_env_for_venv()
     kwargs = _get_subprocess_kwargs()
 
-    auth_code = "import ee; ee.Authenticate()"
+    # Force auth_mode='localhost' so we don't fall back to ee's default
+    # ('gcloud'), which requires the Google Cloud SDK to be installed and
+    # on PATH. 'localhost' opens a browser and runs a tiny callback server
+    # in the venv subprocess — works on a plain QGIS install with no
+    # extra tooling.
+    auth_code = "import ee; ee.Authenticate(auth_mode='localhost')"
 
     if progress_callback:
         progress_callback(50, "Waiting for browser authentication...")
 
-    _log("Running ee.Authenticate() in venv...")
+    _log("Running ee.Authenticate(auth_mode='localhost') in venv...")
 
     try:
         result = subprocess.run(  # nosec B603
@@ -1475,10 +1480,20 @@ def authenticate_ee(
             return True, "Earth Engine authentication completed successfully"
         else:
             error = result.stderr or result.stdout or "Unknown error"
-            _log(f"EE authentication failed: {error[:200]}", Qgis.MessageLevel.Warning)
-            return False, f"Authentication failed: {error[:200]}"
+            # Log the *full* error so users (and #49-style bug reports)
+            # can see the real traceback. The user-facing return value
+            # stays compact for the message bar, with the log channel as
+            # the source of truth.
+            _log(
+                f"EE authentication failed:\n{error}",
+                Qgis.MessageLevel.Warning,
+            )
+            return False, (
+                f"Authentication failed: {error[:500]}"
+                "\n\n(Full traceback in the QGIS Message Log → Timelapse channel.)"
+            )
 
     except subprocess.TimeoutExpired:
         return False, "Authentication timed out (5 minutes)"
     except Exception as e:
-        return False, f"Authentication error: {str(e)[:200]}"
+        return False, f"Authentication error: {str(e)[:500]}"

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -3,7 +3,7 @@ name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, and MODIS NDVI) using Google Earth Engine
-version=0.10.3
+version=0.10.4
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -33,6 +33,9 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.10.4:
+        - Force ee.Authenticate(auth_mode='localhost') so authentication no longer requires the Google Cloud SDK on PATH (#49)
+        - Log the full ee.Authenticate traceback to the Timelapse log channel instead of truncating at 200 chars
     0.10.3:
         - Fix RefreshError on Earth Engine init when the credentials file omits client_id/client_secret (#49); rely on ee.Initialize for credential discovery
     0.10.2:


### PR DESCRIPTION
## Summary
Round 3 of #49. Your latest log:

\`\`\`
2026-05-06T01:41:00 INFO    Running ee.Authenticate() in venv...
2026-05-06T01:41:03 WARNING EE authentication failed: Traceback (most recent call last):
              File \"\", line 1, in
              File \"/.../ee/__init__.py\", line 201, in Authenticate
              retur
\`\`\`

Two real bugs in \`venv_manager.authenticate_ee\`:

1. **Truncated traceback**. Both the log line and the return value used \`error[:200]\`, so we were never seeing the real exception. Switched the log to dump the full traceback into the Timelapse log channel; the user-facing snippet stays compact (500 chars) with a pointer to the log.
2. **Wrong auth_mode**. \`ee.Authenticate()\` with no arguments defaults to \`auth_mode='gcloud'\` in modern earthengine-api, which subprocess-execs the Google Cloud SDK. QGIS users on a plain install don't have \`gcloud\` on PATH, so it raises before a browser ever opens. Forcing \`auth_mode='localhost'\` makes \`ee\` open a browser and run a tiny local callback server itself -- no extra tooling needed.

## Changes
- \`timelapse/core/venv_manager.py\`: pass \`auth_mode='localhost'\` to \`ee.Authenticate\`; log the full subprocess traceback; bump user-facing message to 500 chars with a log pointer.
- \`timelapse/metadata.txt\`: bump to 0.10.4 with changelog.

## Test plan
- [x] \`pytest tests/\` -- 25 passed.
- [x] \`pre-commit run --files <changed>\` -- clean.
- [ ] Manual smoke (issue author / @giswqs): on a fresh \`~/.qgis_timelapse\` venv, click Settings -> Earth Engine -> Authenticate. Expect: a browser tab opens, user signs in, credentials get written to \`~/.config/earthengine/credentials\`, then \`Initialize Earth Engine\` succeeds.