### PR TITLE
Fix #49: bind ephemeral port for ee.Authenticate localhost flow

### DIFF
--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -1451,17 +1451,19 @@ def authenticate_ee(
     env = _get_clean_env_for_venv()
     kwargs = _get_subprocess_kwargs()
 
-    # Force auth_mode='localhost' so we don't fall back to ee's default
-    # ('gcloud'), which requires the Google Cloud SDK to be installed and
-    # on PATH. 'localhost' opens a browser and runs a tiny callback server
-    # in the venv subprocess — works on a plain QGIS install with no
-    # extra tooling.
-    auth_code = "import ee; ee.Authenticate(auth_mode='localhost')"
+    # Use auth_mode='localhost:0' so ee's local OAuth callback server
+    # binds an ephemeral kernel-assigned port instead of the default
+    # 8085 — that fixed port collides with anything already listening
+    # there (issue #49 reproduced as "OSError: [Errno 48] Address
+    # already in use"). 'localhost' (without ':0') was the prior choice
+    # to avoid ee's gcloud default, which requires the Google Cloud SDK
+    # on PATH; the ':0' suffix is documented in ee.oauth.authenticate.
+    auth_code = "import ee; ee.Authenticate(auth_mode='localhost:0')"
 
     if progress_callback:
         progress_callback(50, "Waiting for browser authentication...")
 
-    _log("Running ee.Authenticate(auth_mode='localhost') in venv...")
+    _log("Running ee.Authenticate(auth_mode='localhost:0') in venv...")
 
     try:
         result = subprocess.run(  # nosec B603

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -3,7 +3,7 @@ name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, and MODIS NDVI) using Google Earth Engine
-version=0.10.4
+version=0.10.5
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -33,6 +33,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.10.5:
+        - Use ee.Authenticate(auth_mode='localhost:0') so the OAuth callback binds a kernel-assigned port instead of the default 8085, fixing "Address already in use" auth failures (#49)
     0.10.4:
         - Force ee.Authenticate(auth_mode='localhost') so authentication no longer requires the Google Cloud SDK on PATH (#49)
         - Log the full ee.Authenticate traceback to the Timelapse log channel instead of truncating at 200 chars


### PR DESCRIPTION
## Summary
Round 4 of #49. With the truncation fix from 0.10.4 we finally got the full traceback:

\`\`\`
File ".../ee/oauth.py", line 460, in __init__
    self.server = http.server.HTTPServer(('localhost', port), Handler)
OSError: [Errno 48] Address already in use
\`\`\`

ee's \`localhost\` auth flow binds a fixed port — 8085 by default — and on this machine something else (or a previous attempt's TIME_WAIT socket) was already there. ee's own docstring shows the escape hatch:

> "localhost" - Default port is 8085; use localhost:N set port or **localhost:0 to auto-select.**

Confirmed at \`ee/oauth.py\` line 583 — \`auth_mode.startswith('localhost:')\` parses out the port. Switching to \`auth_mode='localhost:0'\` lets the kernel hand out any free ephemeral port instead.

## Changes
- \`timelapse/core/venv_manager.py\`: \`auth_mode='localhost'\` → \`auth_mode='localhost:0'\`.
- \`timelapse/metadata.txt\`: 0.10.5 with changelog.

## Test plan
- [x] \`pytest tests/\` — 25 passed.
- [x] \`pre-commit run --files <changed>\` — clean.
- [ ] Manual smoke (issue author / @giswqs): on the same Mac that hit EADDRINUSE on 8085, click Settings → Earth Engine → Authenticate. Expect: a browser tab opens, sign-in completes, credentials get written, Initialize succeeds.