### PR TITLE
Tighten timelapse dock layout and reorder Settings buttons

### DIFF
--- a/timelapse/dialogs/settings_dock.py
+++ b/timelapse/dialogs/settings_dock.py
@@ -331,15 +331,16 @@ class SettingsDockWidget(QDockWidget):
         actions_group = QGroupBox("Actions")
         actions_layout = QVBoxLayout(actions_group)
 
+        # Authenticate button (above Initialize: users typically need to
+        # authenticate before they can initialize, so put that step first).
+        auth_btn = QPushButton("Authenticate (opens browser)")
+        auth_btn.clicked.connect(self._authenticate_ee)
+        actions_layout.addWidget(auth_btn)
+
         # Initialize button
         init_btn = QPushButton("Initialize Earth Engine")
         init_btn.clicked.connect(self._initialize_ee)
         actions_layout.addWidget(init_btn)
-
-        # Authenticate button
-        auth_btn = QPushButton("Authenticate (opens browser)")
-        auth_btn.clicked.connect(self._authenticate_ee)
-        actions_layout.addWidget(auth_btn)
 
         # Status
         self.ee_status_label = QLabel("Status: Not initialized")

--- a/timelapse/dialogs/timelapse_dock.py
+++ b/timelapse/dialogs/timelapse_dock.py
@@ -379,6 +379,13 @@ class TimelapseDockWidget(QDockWidget):
         vis_tab = self.create_visualization_tab()
         self.tabs.addTab(vis_tab, "Style")
 
+        # Without this, QTabWidget sizes to its tallest tab, leaving a
+        # large gap between the active tab's content and the Progress
+        # section below when a shorter tab (AOI / Output / Style) is
+        # selected. Setting Ignored on hidden tabs lets the QTabWidget
+        # shrink to the current tab's preferred height.
+        self.tabs.currentChanged.connect(self._on_tab_changed)
+
         layout.addWidget(self.tabs)
 
         # Initialize imagery options after all tabs are created
@@ -431,6 +438,32 @@ class TimelapseDockWidget(QDockWidget):
         button_layout.addWidget(self.cancel_button, 1)
 
         layout.addLayout(button_layout)
+
+        # Apply the tab-size-fits-content policy now that all tabs exist.
+        self._on_tab_changed(self.tabs.currentIndex())
+
+    def _on_tab_changed(self, index: int) -> None:
+        """Shrink the tab widget to the current tab's preferred height.
+
+        QTabWidget's default size hint is the maximum of all tab pages,
+        so a short tab leaves a visible gap between its content and the
+        Progress section below. Marking hidden tabs with an Ignored size
+        policy excludes them from the size hint calculation; the active
+        tab keeps Preferred so it sizes to its content.
+        """
+        for i in range(self.tabs.count()):
+            page = self.tabs.widget(i)
+            if page is None:
+                continue
+            policy = (
+                QSizePolicy.Policy.Preferred
+                if i == index
+                else QSizePolicy.Policy.Ignored
+            )
+            page.setSizePolicy(policy, policy)
+        active = self.tabs.widget(index)
+        if active is not None:
+            active.adjustSize()
 
     def create_aoi_tab(self):
         """Create the Area of Interest tab."""

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -3,7 +3,7 @@ name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, and MODIS NDVI) using Google Earth Engine
-version=0.10.5
+version=0.10.6
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -33,6 +33,9 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.10.6:
+        - Shrink the timelapse dock's tab area to the current tab's content so the AOI / Output / Style tabs no longer leave a visible gap above the Progress section
+        - Reorder Settings -> Earth Engine actions so Authenticate appears above Initialize
     0.10.5:
         - Use ee.Authenticate(auth_mode='localhost:0') so the OAuth callback binds a kernel-assigned port instead of the default 8085, fixing "Address already in use" auth failures (#49)
     0.10.4:


### PR DESCRIPTION
## Summary
- The timelapse dock's QTabWidget sized itself to the tallest tab (Imagery), so the AOI / Output / Style tabs all left a large empty gap between their content and the Progress section that follows. Hooking ``currentChanged`` and marking hidden tabs with ``QSizePolicy.Ignored`` lets the widget shrink to the active tab's preferred height — standard Qt fix for this exact pattern.
- Swap the order of the **Authenticate** and **Initialize Earth Engine** buttons in Settings → Earth Engine. Authenticate is the typical first step, so it should appear first.

## Changes
- ``timelapse/dialogs/timelapse_dock.py``: connect ``self.tabs.currentChanged`` to a new ``_on_tab_changed`` slot; call it once after tabs are populated.
- ``timelapse/dialogs/settings_dock.py``: swap the two ``addWidget`` calls in the EE Actions group.
- ``timelapse/metadata.txt``: bump to 0.10.6 with changelog.

## Test plan
- [x] ``pytest tests/`` — 25 passed.
- [x] ``pre-commit run --files <changed>`` — clean.
- [ ] Manual smoke: open the dock on the AOI tab — the Progress section should now sit immediately below the GEE group with no gap. Switch to Imagery and back; the dock should resize cleanly each time.
- [ ] Manual smoke: open Settings → Earth Engine — Authenticate is the first button, Initialize is below it.