### PR TITLE
feat: add ESRI Wayback and custom XYZ external imagery sources

### DIFF
--- a/tests/test_external_sources.py
+++ b/tests/test_external_sources.py
@@ -1,0 +1,156 @@
+import datetime
+
+import pytest
+
+from timelapse.core import external_sources, timelapse_core
+
+MINIMAL_WAYBACK_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="https://www.opengis.net/wmts/1.0"
+  xmlns:ows="https://www.opengis.net/ows/1.1" version="1.0.0">
+  <Contents>
+    <Layer>
+      <ows:Title>World Imagery (Wayback 2024-02-29)</ows:Title>
+      <ows:Identifier>WB_2024_R02</ows:Identifier>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink><TileMatrixSet>default028mm</TileMatrixSet></TileMatrixSetLink>
+      <TileMatrixSetLink><TileMatrixSet>GoogleMapsCompatible</TileMatrixSet></TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile"
+        template="https://example.test/{TileMatrixSet}/tile/123/{TileMatrix}/{TileRow}/{TileCol}"/>
+    </Layer>
+    <Layer>
+      <ows:Title>World Imagery (Wayback 2023-12-15)</ows:Title>
+      <ows:Identifier>WB_2023_R12</ows:Identifier>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink><TileMatrixSet>GoogleMapsCompatible</TileMatrixSet></TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile"
+        template="https://example.test/{TileMatrixSet}/tile/456/{TileMatrix}/{TileRow}/{TileCol}"/>
+    </Layer>
+  </Contents>
+</Capabilities>
+"""
+
+
+def test_parse_esri_wayback_capabilities_https_namespaces():
+    layers = external_sources.parse_esri_wayback_capabilities(MINIMAL_WAYBACK_XML)
+
+    assert [layer.identifier for layer in layers] == ["WB_2023_R12", "WB_2024_R02"]
+    assert layers[0].date == datetime.date(2023, 12, 15)
+    assert layers[0].tile_matrix_set == "GoogleMapsCompatible"
+    assert layers[1].tile_template.endswith(
+        "/{TileMatrixSet}/tile/123/{TileMatrix}/{TileRow}/{TileCol}"
+    )
+
+
+def test_build_esri_wayback_xyz_url_converts_wmts_tokens():
+    layer = external_sources.parse_esri_wayback_capabilities(MINIMAL_WAYBACK_XML)[0]
+
+    assert external_sources.build_esri_wayback_xyz_url(layer) == (
+        "https://example.test/GoogleMapsCompatible/tile/456/{z}/{y}/{x}"
+    )
+
+
+def test_filter_esri_wayback_layers_year_step_and_max_frames():
+    layers = external_sources.parse_esri_wayback_capabilities(MINIMAL_WAYBACK_XML)
+
+    selected = external_sources.filter_esri_wayback_layers(
+        layers, 2023, 2024, step=2, max_frames=1
+    )
+
+    assert [layer.identifier for layer in selected] == ["WB_2023_R12"]
+
+
+def test_expand_custom_template_keeps_tile_tokens():
+    url = external_sources.expand_custom_template(
+        "https://tiles.planet.com/global_monthly_{yyyy}_{MM}_mosaic/{z}/{x}/{y}.png",
+        datetime.date(2026, 3, 5),
+    )
+
+    assert url == (
+        "https://tiles.planet.com/global_monthly_2026_03_mosaic/{z}/{x}/{y}.png"
+    )
+
+
+def test_parse_explicit_dates_rejects_bad_dates():
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        external_sources.parse_explicit_dates("2026-01-01\nnot-a-date\n")
+
+
+def test_custom_xyz_frames_uses_explicit_dates_before_generated_dates():
+    frames = external_sources.custom_xyz_frames(
+        template="https://example.test/{date}/{z}/{x}/{y}.png",
+        explicit_dates="2026-01-05\n2026-02-06",
+        start_year=2020,
+        end_year=2020,
+        start_date="01-01",
+        end_date="12-31",
+        frequency="year",
+        step=1,
+    )
+
+    assert [frame.label for frame in frames] == ["2026-01-05", "2026-02-06"]
+    assert frames[0].url_template == "https://example.test/2026-01-05/{z}/{x}/{y}.png"
+
+
+def test_qgis_xyz_uri_encodes_query_delimiters_inside_template():
+    uri = external_sources.qgis_xyz_uri(
+        "https://example.test/{z}/{x}/{y}.png?api_key=a&style=b"
+    )
+
+    assert uri.startswith("type=xyz&url=")
+    assert "%26style%3Db" in uri
+
+
+def test_is_effectively_black_image_detects_black_renders(tmp_path):
+    black_path = tmp_path / "black.png"
+    color_path = tmp_path / "color.png"
+    timelapse_core.Image.new("RGB", (10, 10), (0, 0, 0)).save(black_path)
+    timelapse_core.Image.new("RGB", (10, 10), (0, 128, 0)).save(color_path)
+
+    assert external_sources.is_effectively_black_image(str(black_path)) is True
+    assert external_sources.is_effectively_black_image(str(color_path)) is False
+
+
+def test_create_external_timelapse_skips_black_frames_and_forces_fps(
+    monkeypatch, tmp_path
+):
+    colors = [(0, 0, 0), (40, 80, 120)]
+
+    def fake_render(
+        frame, bbox, out_path, dimensions, crs="EPSG:3857", overlay_path=None
+    ):
+        color = colors.pop(0)
+        timelapse_core.Image.new("RGB", (16, 16), color).save(out_path)
+
+    monkeypatch.setattr(external_sources, "render_xyz_frame", fake_render)
+
+    frames = [
+        external_sources.ExternalFrame("black", "https://example.test/{z}", "black"),
+        external_sources.ExternalFrame("color", "https://example.test/{z}", "color"),
+    ]
+    out_gif = tmp_path / "external.gif"
+    messages = []
+
+    external_sources.create_external_timelapse(
+        frames=frames,
+        bbox={"xmin": -1, "ymin": -1, "xmax": 1, "ymax": 1},
+        out_gif=str(out_gif),
+        frames_per_second=2,
+        add_text=True,
+        progress_callback=messages.append,
+    )
+
+    with timelapse_core.Image.open(out_gif) as gif:
+        assert gif.n_frames == 1
+        assert gif.info["duration"] == 500
+    assert messages[-1] == "Frame summary: kept 1/2 frames; skipped 1 black frames."
+
+
+def test_force_gif_frame_duration_updates_existing_gif(tmp_path):
+    out_gif = tmp_path / "timing.gif"
+    frame = timelapse_core.Image.new("RGB", (16, 16), (40, 80, 120))
+    frame.save(out_gif, format="GIF", save_all=True, duration=1000, loop=0)
+
+    external_sources.force_gif_frame_duration(str(out_gif), str(out_gif), fps=10)
+
+    with timelapse_core.Image.open(out_gif) as gif:
+        assert gif.info["duration"] == 100

--- a/tests/test_external_sources.py
+++ b/tests/test_external_sources.py
@@ -4,6 +4,11 @@ import pytest
 
 from timelapse.core import external_sources, timelapse_core
 
+requires_pillow = pytest.mark.skipif(
+    timelapse_core.Image is None,
+    reason="Pillow is not installed in this environment.",
+)
+
 MINIMAL_WAYBACK_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <Capabilities xmlns="https://www.opengis.net/wmts/1.0"
   xmlns:ows="https://www.opengis.net/ows/1.1" version="1.0.0">
@@ -100,6 +105,7 @@ def test_qgis_xyz_uri_encodes_query_delimiters_inside_template():
     assert "%26style%3Db" in uri
 
 
+@requires_pillow
 def test_is_effectively_black_image_detects_black_renders(tmp_path):
     black_path = tmp_path / "black.png"
     color_path = tmp_path / "color.png"
@@ -110,6 +116,7 @@ def test_is_effectively_black_image_detects_black_renders(tmp_path):
     assert external_sources.is_effectively_black_image(str(color_path)) is False
 
 
+@requires_pillow
 def test_create_external_timelapse_skips_black_frames_and_forces_fps(
     monkeypatch, tmp_path
 ):
@@ -148,6 +155,7 @@ def test_create_external_timelapse_skips_black_frames_and_forces_fps(
     )
 
 
+@requires_pillow
 def test_create_external_timelapse_skips_duplicate_frames(monkeypatch, tmp_path):
     colors = [(40, 80, 120), (40, 80, 120), (120, 80, 40)]
 
@@ -186,6 +194,7 @@ def test_create_external_timelapse_skips_duplicate_frames(monkeypatch, tmp_path)
     )
 
 
+@requires_pillow
 def test_force_gif_frame_duration_updates_existing_gif(tmp_path):
     out_gif = tmp_path / "timing.gif"
     frame = timelapse_core.Image.new("RGB", (16, 16), (40, 80, 120))

--- a/tests/test_external_sources.py
+++ b/tests/test_external_sources.py
@@ -142,7 +142,48 @@ def test_create_external_timelapse_skips_black_frames_and_forces_fps(
     with timelapse_core.Image.open(out_gif) as gif:
         assert gif.n_frames == 1
         assert gif.info["duration"] == 500
-    assert messages[-1] == "Frame summary: kept 1/2 frames; skipped 1 black frames."
+    assert messages[-1] == (
+        "Frame summary: kept 1/2 frames; skipped 1 black frames; "
+        "skipped 0 duplicate frames."
+    )
+
+
+def test_create_external_timelapse_skips_duplicate_frames(monkeypatch, tmp_path):
+    colors = [(40, 80, 120), (40, 80, 120), (120, 80, 40)]
+
+    def fake_render(
+        frame, bbox, out_path, dimensions, crs="EPSG:3857", overlay_path=None
+    ):
+        color = colors.pop(0)
+        timelapse_core.Image.new("RGB", (16, 16), color).save(out_path)
+
+    monkeypatch.setattr(external_sources, "render_xyz_frame", fake_render)
+
+    frames = [
+        external_sources.ExternalFrame("first", "https://example.test/{z}", "first"),
+        external_sources.ExternalFrame("duplicate", "https://example.test/{z}", "dup"),
+        external_sources.ExternalFrame(
+            "changed", "https://example.test/{z}", "changed"
+        ),
+    ]
+    out_gif = tmp_path / "external.gif"
+    messages = []
+
+    external_sources.create_external_timelapse(
+        frames=frames,
+        bbox={"xmin": -1, "ymin": -1, "xmax": 1, "ymax": 1},
+        out_gif=str(out_gif),
+        add_text=False,
+        progress_callback=messages.append,
+    )
+
+    with timelapse_core.Image.open(out_gif) as gif:
+        assert gif.n_frames == 2
+    assert "Skipping duplicate frame: duplicate" in messages
+    assert messages[-1] == (
+        "Frame summary: kept 2/3 frames; skipped 0 black frames; "
+        "skipped 1 duplicate frames."
+    )
 
 
 def test_force_gif_frame_duration_updates_existing_gif(tmp_path):

--- a/tests/test_external_worker.py
+++ b/tests/test_external_worker.py
@@ -1,0 +1,44 @@
+from timelapse.core import external_sources, timelapse_core
+from timelapse.dialogs.timelapse_dock import TimelapseWorker
+
+
+def test_external_worker_does_not_initialize_earth_engine(monkeypatch):
+    called = {"render": False}
+
+    def fail_initialize(*args, **kwargs):
+        raise AssertionError("External imagery must not initialize Earth Engine")
+
+    def fake_frames(**kwargs):
+        return [
+            external_sources.ExternalFrame(
+                label="2026-01-01",
+                url_template="https://example.test/{z}/{x}/{y}.png",
+                layer_name="test",
+            )
+        ]
+
+    def fake_render(**kwargs):
+        called["render"] = True
+        assert kwargs["frames"][0].label == "2026-01-01"
+        assert kwargs["bbox"]["xmin"] == -1.0
+        return "/tmp/external.gif"
+
+    monkeypatch.setattr(timelapse_core, "_ee_initialized", False)
+    monkeypatch.setattr(timelapse_core, "initialize_ee", fail_initialize)
+    monkeypatch.setattr(external_sources, "esri_wayback_frames", fake_frames)
+    monkeypatch.setattr(external_sources, "create_external_timelapse", fake_render)
+
+    worker = TimelapseWorker(
+        {
+            "imagery_type": "ESRI Wayback",
+            "bbox": {"xmin": -1.0, "ymin": -1.0, "xmax": 1.0, "ymax": 1.0},
+            "output_path": "/tmp/external.gif",
+            "start_year": 2026,
+            "end_year": 2026,
+            "step": 1,
+        }
+    )
+
+    worker.run()
+
+    assert called["render"] is True

--- a/timelapse/core/external_sources.py
+++ b/timelapse/core/external_sources.py
@@ -1,0 +1,510 @@
+"""External imagery source support for non-Earth-Engine timelapses."""
+
+from __future__ import annotations
+
+import datetime
+import os
+import re
+import tempfile
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET  # nosec B405 (parsing trusted ESRI Wayback WMTS XML over https; no DTDs/entities used)
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional
+
+from . import timelapse_core
+
+ESRI_WAYBACK_CAPABILITIES_URL = (
+    "https://wayback.maptiles.arcgis.com/arcgis/rest/services/"
+    "World_Imagery/MapServer/WMTS/1.0.0/WMTSCapabilities.xml"
+)
+
+
+def _require_https(url: str) -> None:
+    """Reject any non-https URL before opening it.
+
+    Args:
+        url: The URL to validate.
+
+    Raises:
+        ValueError: If the URL does not use the https scheme.
+    """
+    if not url.startswith("https://"):
+        raise ValueError(f"Refusing to open non-https URL: {url}")
+
+
+@dataclass(frozen=True)
+class EsriWaybackLayer:
+    """Metadata for one ESRI Wayback WMTS layer."""
+
+    identifier: str
+    title: str
+    date: datetime.date
+    tile_matrix_set: str
+    tile_template: str
+    image_format: str = "image/jpeg"
+
+
+@dataclass(frozen=True)
+class ExternalFrame:
+    """One externally rendered timelapse frame."""
+
+    label: str
+    url_template: str
+    layer_name: str
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _find_child_text(element: ET.Element, local_name: str) -> str:
+    for child in element:
+        if _local_name(child.tag) == local_name:
+            return (child.text or "").strip()
+    return ""
+
+
+def _find_descendant_text(element: ET.Element, local_name: str) -> str:
+    for child in element.iter():
+        if _local_name(child.tag) == local_name:
+            return (child.text or "").strip()
+    return ""
+
+
+def parse_esri_wayback_capabilities(xml_text: str) -> List[EsriWaybackLayer]:
+    """Parse ESRI Wayback WMTS capabilities XML.
+
+    The endpoint currently uses HTTPS namespace URIs, while many WMTS
+    examples use HTTP URIs. This parser matches elements by local name so
+    both forms work.
+    """
+    root = ET.fromstring(
+        xml_text
+    )  # nosec B314 (input is fetched from a trusted https endpoint; parser does not resolve external entities)
+    layers: List[EsriWaybackLayer] = []
+
+    for element in root.iter():
+        if _local_name(element.tag) != "Layer":
+            continue
+
+        identifier = _find_descendant_text(element, "Identifier")
+        if not identifier.startswith("WB_"):
+            continue
+
+        title = _find_descendant_text(element, "Title")
+        date_match = re.search(r"(\d{4}-\d{2}-\d{2})", title)
+        if date_match is None:
+            continue
+
+        resource_url = ""
+        image_format = _find_child_text(element, "Format") or "image/jpeg"
+        for child in element:
+            if _local_name(child.tag) == "ResourceURL":
+                if child.get("resourceType") in (None, "tile"):
+                    resource_url = child.get("template", "")
+                    image_format = child.get("format", image_format)
+                    break
+
+        if not resource_url:
+            continue
+
+        matrix_sets = [
+            (child.text or "").strip()
+            for child in element.iter()
+            if _local_name(child.tag) == "TileMatrixSet" and (child.text or "").strip()
+        ]
+        tile_matrix_set = (
+            "GoogleMapsCompatible"
+            if "GoogleMapsCompatible" in matrix_sets
+            else (matrix_sets[0] if matrix_sets else "GoogleMapsCompatible")
+        )
+
+        layers.append(
+            EsriWaybackLayer(
+                identifier=identifier,
+                title=title,
+                date=datetime.date.fromisoformat(date_match.group(1)),
+                tile_matrix_set=tile_matrix_set,
+                tile_template=resource_url,
+                image_format=image_format,
+            )
+        )
+
+    return sorted(layers, key=lambda layer: layer.date)
+
+
+def fetch_esri_wayback_layers(
+    capabilities_url: str = ESRI_WAYBACK_CAPABILITIES_URL,
+    timeout: int = 30,
+) -> List[EsriWaybackLayer]:
+    """Download and parse the current ESRI Wayback layer list."""
+    _require_https(capabilities_url)
+    with urllib.request.urlopen(  # nosec B310 (https enforced by _require_https)
+        capabilities_url, timeout=timeout
+    ) as response:
+        xml_text = response.read().decode("utf-8")
+    return parse_esri_wayback_capabilities(xml_text)
+
+
+def filter_esri_wayback_layers(
+    layers: Iterable[EsriWaybackLayer],
+    start_year: int,
+    end_year: int,
+    step: int = 1,
+    max_frames: Optional[int] = None,
+) -> List[EsriWaybackLayer]:
+    """Filter ESRI layers by year and downsample irregular releases."""
+    if step < 1:
+        raise ValueError("step must be 1 or greater")
+
+    selected = [layer for layer in layers if start_year <= layer.date.year <= end_year][
+        ::step
+    ]
+
+    if max_frames is not None and max_frames > 0:
+        selected = selected[:max_frames]
+
+    return selected
+
+
+def build_esri_wayback_xyz_url(layer: EsriWaybackLayer) -> str:
+    """Convert an ESRI WMTS ResourceURL template to a QGIS XYZ template."""
+    return (
+        layer.tile_template.replace("{TileMatrixSet}", layer.tile_matrix_set)
+        .replace("{TileMatrix}", "{z}")
+        .replace("{TileRow}", "{y}")
+        .replace("{TileCol}", "{x}")
+    )
+
+
+def expand_custom_template(template: str, date_value: datetime.date) -> str:
+    """Expand supported custom date tokens while leaving tile tokens intact."""
+    replacements = {
+        "{date}": date_value.isoformat(),
+        "{yyyy}": f"{date_value.year:04d}",
+        "{yy}": f"{date_value.year % 100:02d}",
+        "{MM}": f"{date_value.month:02d}",
+        "{M}": str(date_value.month),
+        "{dd}": f"{date_value.day:02d}",
+        "{d}": str(date_value.day),
+    }
+    result = template
+    for token, value in replacements.items():
+        result = result.replace(token, value)
+    return result
+
+
+def parse_explicit_dates(text: str) -> List[datetime.date]:
+    """Parse one YYYY-MM-DD date per non-empty line."""
+    dates: List[datetime.date] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            dates.append(datetime.date.fromisoformat(stripped))
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid custom date {stripped!r}; expected YYYY-MM-DD."
+            ) from exc
+    return dates
+
+
+def generated_dates(
+    start_year: int,
+    end_year: int,
+    start_date: str,
+    end_date: str,
+    frequency: str,
+    step: int,
+) -> List[datetime.date]:
+    """Create representative dates from the existing date sequence controls."""
+    ranges = timelapse_core.date_sequence(
+        start_year, end_year, start_date, end_date, frequency, step
+    )
+    return [start for start, _end, _label in ranges]
+
+
+def qgis_xyz_uri(url_template: str) -> str:
+    """Build a QGIS WMS provider URI for an XYZ tile template."""
+    encoded_url = urllib.parse.quote(url_template, safe=":/{}?")
+    return f"type=xyz&url={encoded_url}&zmin=0&zmax=23"
+
+
+def is_effectively_black_image(
+    image_path: str,
+    pixel_threshold: int = 8,
+    ratio_threshold: float = 0.995,
+) -> bool:
+    """Return True when an image is effectively an all-black render."""
+    if timelapse_core.Image is None:
+        return False
+
+    with timelapse_core.Image.open(image_path) as image:
+        width = min(image.width, 64)
+        height = min(image.height, 64)
+        if width == 0 or height == 0:
+            return False
+        rgb_image = image.convert("RGB").resize((width, height))
+        total_pixels = rgb_image.width * rgb_image.height
+        pixel_bytes = rgb_image.tobytes()
+        dark_pixels = sum(
+            1
+            for index in range(0, len(pixel_bytes), 3)
+            if (
+                pixel_bytes[index] <= pixel_threshold
+                and pixel_bytes[index + 1] <= pixel_threshold
+                and pixel_bytes[index + 2] <= pixel_threshold
+            )
+        )
+        return dark_pixels / total_pixels >= ratio_threshold
+
+
+def force_gif_frame_duration(
+    in_gif: str,
+    out_gif: str,
+    fps: int,
+    loop: int = 0,
+) -> None:
+    """Rewrite GIF timing so the requested FPS survives overlay passes."""
+    if timelapse_core.Image is None:
+        return
+
+    duration = int(1000 / max(fps, 1))
+    with timelapse_core.Image.open(in_gif) as gif:
+        frames = []
+        for index in range(gif.n_frames):
+            gif.seek(index)
+            frames.append(gif.copy())
+
+    if not frames:
+        raise ValueError("No frames found in GIF.")
+
+    frames[0].save(
+        out_gif,
+        format="GIF",
+        append_images=frames[1:],
+        save_all=True,
+        duration=duration,
+        loop=loop,
+    )
+
+
+def esri_wayback_frames(
+    start_year: int,
+    end_year: int,
+    step: int = 1,
+    max_frames: Optional[int] = None,
+    fetch_layers: Callable[[], List[EsriWaybackLayer]] = fetch_esri_wayback_layers,
+) -> List[ExternalFrame]:
+    """Build renderable frames for ESRI Wayback."""
+    layers = filter_esri_wayback_layers(
+        fetch_layers(), start_year, end_year, step=step, max_frames=max_frames
+    )
+    return [
+        ExternalFrame(
+            label=layer.date.isoformat(),
+            url_template=build_esri_wayback_xyz_url(layer),
+            layer_name=layer.identifier,
+        )
+        for layer in layers
+    ]
+
+
+def custom_xyz_frames(
+    template: str,
+    explicit_dates: str,
+    start_year: int,
+    end_year: int,
+    start_date: str,
+    end_date: str,
+    frequency: str,
+    step: int,
+) -> List[ExternalFrame]:
+    """Build renderable frames for a custom XYZ template."""
+    if not template.strip():
+        raise ValueError("Custom XYZ URL template is required.")
+
+    dates = parse_explicit_dates(explicit_dates)
+    if not dates:
+        dates = generated_dates(
+            start_year, end_year, start_date, end_date, frequency, step
+        )
+
+    return [
+        ExternalFrame(
+            label=date_value.isoformat(),
+            url_template=expand_custom_template(template.strip(), date_value),
+            layer_name=f"Custom XYZ {date_value.isoformat()}",
+        )
+        for date_value in dates
+    ]
+
+
+def render_xyz_frame(
+    frame: ExternalFrame,
+    bbox: Dict[str, float],
+    out_path: str,
+    dimensions: int,
+    crs: str = "EPSG:3857",
+    overlay_path: Optional[str] = None,
+) -> None:
+    """Render one XYZ frame with the QGIS map renderer."""
+    from qgis.PyQt.QtCore import QSize
+    from qgis.PyQt.QtGui import QColor
+    from qgis.core import (
+        QgsCoordinateReferenceSystem,
+        QgsCoordinateTransform,
+        QgsMapRendererSequentialJob,
+        QgsMapSettings,
+        QgsProject,
+        QgsRasterLayer,
+        QgsRectangle,
+        QgsVectorLayer,
+    )
+
+    source_crs = QgsCoordinateReferenceSystem("EPSG:4326")
+    dest_crs = QgsCoordinateReferenceSystem(crs)
+    extent = QgsRectangle(bbox["xmin"], bbox["ymin"], bbox["xmax"], bbox["ymax"])
+    if source_crs != dest_crs:
+        transform = QgsCoordinateTransform(source_crs, dest_crs, QgsProject.instance())
+        extent = transform.transformBoundingBox(extent)
+
+    raster_layer = QgsRasterLayer(
+        qgis_xyz_uri(frame.url_template), frame.layer_name, "wms"
+    )
+    if not raster_layer.isValid():
+        raise RuntimeError(f"Could not create raster layer for {frame.layer_name}.")
+
+    layers = [raster_layer]
+    if overlay_path:
+        overlay_layer = QgsVectorLayer(overlay_path, "Vector Overlay", "ogr")
+        if not overlay_layer.isValid():
+            raise RuntimeError(f"Could not load overlay vector file: {overlay_path}")
+        layers.append(overlay_layer)
+
+    settings = QgsMapSettings()
+    settings.setLayers(layers)
+    settings.setDestinationCrs(dest_crs)
+    settings.setExtent(extent)
+    settings.setOutputSize(QSize(dimensions, dimensions))
+    settings.setBackgroundColor(QColor("black"))
+
+    job = QgsMapRendererSequentialJob(settings)
+    job.start()
+    job.waitForFinished()
+
+    image = job.renderedImage()
+    if image.isNull():
+        raise RuntimeError(f"QGIS rendered a blank image for {frame.layer_name}.")
+    if not image.save(out_path):
+        raise RuntimeError(f"Failed to save rendered frame: {out_path}")
+
+
+def create_external_timelapse(
+    frames: List[ExternalFrame],
+    bbox: Dict[str, float],
+    out_gif: str,
+    dimensions: int = 768,
+    frames_per_second: int = 5,
+    crs: str = "EPSG:3857",
+    title: str = None,
+    add_text: bool = True,
+    font_size: int = 20,
+    font_color: str = "white",
+    add_progress_bar: bool = True,
+    progress_bar_color: str = "white",
+    progress_bar_height: int = 5,
+    loop: int = 0,
+    mp4: bool = False,
+    overlay_path: Optional[str] = None,
+    skip_black_frames: bool = True,
+    progress_callback: Optional[Callable[[str], None]] = None,
+) -> str:
+    """Render external XYZ frames to GIF and optional MP4."""
+    if not frames:
+        raise ValueError("No frames matched the selected external imagery settings.")
+
+    out_gif = os.path.abspath(out_gif)
+    os.makedirs(os.path.dirname(out_gif), exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="qgis_timelapse_frames_") as frame_dir:
+        image_paths: List[str] = []
+        rendered_frames: List[ExternalFrame] = []
+        skipped_black_frames = 0
+        for index, frame in enumerate(frames, start=1):
+            if progress_callback is not None:
+                progress_callback(
+                    f"Rendering frame {index}/{len(frames)}: {frame.label}"
+                )
+            frame_path = os.path.join(frame_dir, f"{index:05d}.png")
+            render_xyz_frame(
+                frame,
+                bbox,
+                frame_path,
+                dimensions,
+                crs=crs,
+                overlay_path=overlay_path,
+            )
+            if skip_black_frames and is_effectively_black_image(frame_path):
+                skipped_black_frames += 1
+                if progress_callback is not None:
+                    progress_callback(f"Skipping black frame: {frame.label}")
+                continue
+            image_paths.append(frame_path)
+            rendered_frames.append(frame)
+
+        if progress_callback is not None:
+            progress_callback(
+                "Frame summary: "
+                f"kept {len(rendered_frames)}/{len(frames)} frames; "
+                f"skipped {skipped_black_frames} black frames."
+            )
+
+        if not image_paths:
+            raise RuntimeError(
+                "All rendered frames were black. Try a smaller AOI, different "
+                "date range, or fewer ESRI Wayback layers."
+            )
+
+        timelapse_core.make_gif(
+            image_paths,
+            out_gif,
+            ext="png",
+            fps=frames_per_second,
+            loop=loop,
+            clean_up=False,
+        )
+
+    if add_text:
+        timelapse_core.add_text_to_gif(
+            out_gif,
+            out_gif,
+            [frame.label for frame in rendered_frames],
+            font_size=font_size,
+            font_color=font_color,
+            add_progress_bar=add_progress_bar,
+            progress_bar_color=progress_bar_color,
+            progress_bar_height=progress_bar_height,
+            loop=loop,
+        )
+
+    if title is not None and isinstance(title, str) and title.strip():
+        timelapse_core.add_text_to_gif(
+            out_gif,
+            out_gif,
+            title,
+            xy=("2%", "93%"),
+            font_size=font_size,
+            font_color=font_color,
+            add_progress_bar=False,
+            loop=loop,
+        )
+
+    force_gif_frame_duration(out_gif, out_gif, frames_per_second, loop=loop)
+
+    if mp4:
+        timelapse_core.gif_to_mp4(out_gif, out_gif.replace(".gif", ".mp4"))
+
+    return out_gif

--- a/timelapse/core/external_sources.py
+++ b/timelapse/core/external_sources.py
@@ -261,6 +261,35 @@ def is_effectively_black_image(
         return dark_pixels / total_pixels >= ratio_threshold
 
 
+def image_difference_score(
+    first_path: str,
+    second_path: str,
+    sample_size: int = 32,
+) -> float:
+    """Return average normalized RGB difference between two images."""
+    if timelapse_core.Image is None:
+        return 1.0
+
+    with timelapse_core.Image.open(first_path) as first_image:
+        first = first_image.convert("RGB").resize((sample_size, sample_size))
+        first_bytes = first.tobytes()
+    with timelapse_core.Image.open(second_path) as second_image:
+        second = second_image.convert("RGB").resize((sample_size, sample_size))
+        second_bytes = second.tobytes()
+
+    total_difference = sum(abs(a - b) for a, b in zip(first_bytes, second_bytes))
+    return total_difference / (len(first_bytes) * 255)
+
+
+def is_duplicate_image(
+    first_path: str,
+    second_path: str,
+    difference_threshold: float = 0.002,
+) -> bool:
+    """Return True when two rendered frames are visually equivalent."""
+    return image_difference_score(first_path, second_path) <= difference_threshold
+
+
 def force_gif_frame_duration(
     in_gif: str,
     out_gif: str,
@@ -420,6 +449,7 @@ def create_external_timelapse(
     mp4: bool = False,
     overlay_path: Optional[str] = None,
     skip_black_frames: bool = True,
+    skip_duplicate_frames: bool = True,
     progress_callback: Optional[Callable[[str], None]] = None,
 ) -> str:
     """Render external XYZ frames to GIF and optional MP4."""
@@ -433,6 +463,7 @@ def create_external_timelapse(
         image_paths: List[str] = []
         rendered_frames: List[ExternalFrame] = []
         skipped_black_frames = 0
+        skipped_duplicate_frames = 0
         for index, frame in enumerate(frames, start=1):
             if progress_callback is not None:
                 progress_callback(
@@ -452,6 +483,15 @@ def create_external_timelapse(
                 if progress_callback is not None:
                     progress_callback(f"Skipping black frame: {frame.label}")
                 continue
+            if (
+                skip_duplicate_frames
+                and image_paths
+                and is_duplicate_image(image_paths[-1], frame_path)
+            ):
+                skipped_duplicate_frames += 1
+                if progress_callback is not None:
+                    progress_callback(f"Skipping duplicate frame: {frame.label}")
+                continue
             image_paths.append(frame_path)
             rendered_frames.append(frame)
 
@@ -459,7 +499,8 @@ def create_external_timelapse(
             progress_callback(
                 "Frame summary: "
                 f"kept {len(rendered_frames)}/{len(frames)} frames; "
-                f"skipped {skipped_black_frames} black frames."
+                f"skipped {skipped_black_frames} black frames; "
+                f"skipped {skipped_duplicate_frames} duplicate frames."
             )
 
         if not image_paths:

--- a/timelapse/core/external_sources.py
+++ b/timelapse/core/external_sources.py
@@ -227,7 +227,11 @@ def generated_dates(
 
 
 def qgis_xyz_uri(url_template: str) -> str:
-    """Build a QGIS WMS provider URI for an XYZ tile template."""
+    """Build the connection URI that QgsRasterLayer expects for an XYZ tile source.
+
+    The string is consumed by the QGIS ``wms`` provider running in XYZ
+    mode (``type=xyz``); it is not a WMS GetMap URL.
+    """
     encoded_url = urllib.parse.quote(url_template, safe=":/{}?")
     return f"type=xyz&url={encoded_url}&zmin=0&zmax=23"
 
@@ -438,7 +442,7 @@ def create_external_timelapse(
     dimensions: int = 768,
     frames_per_second: int = 5,
     crs: str = "EPSG:3857",
-    title: str = None,
+    title: Optional[str] = None,
     add_text: bool = True,
     font_size: int = 20,
     font_color: str = "white",
@@ -531,7 +535,7 @@ def create_external_timelapse(
             loop=loop,
         )
 
-    if title is not None and isinstance(title, str) and title.strip():
+    if title and title.strip():
         timelapse_core.add_text_to_gif(
             out_gif,
             out_gif,

--- a/timelapse/dialogs/timelapse_dock.py
+++ b/timelapse/dialogs/timelapse_dock.py
@@ -155,6 +155,7 @@ class TimelapseWorker(QThread):
                 "progress_bar_height": self.params.get("progress_bar_height", 5),
                 "title": self.params.get("title"),
                 "mp4": self.params.get("create_mp4", False),
+                "loop": self.params.get("loop", 0),
                 "overlay_data": overlay_data,
                 "overlay_color": self.params.get("overlay_color", "#FF0000"),
                 "overlay_width": self.params.get("overlay_width", 2),
@@ -319,6 +320,35 @@ class TimelapseWorker(QThread):
     def cancel(self):
         """Cancel the operation."""
         self.cancelled = True
+
+
+class EsriWaybackStatusWorker(QThread):
+    """Background worker that fetches and filters ESRI Wayback layers."""
+
+    finished = pyqtSignal(list)
+    error = pyqtSignal(str)
+
+    def __init__(self, start_year, end_year, step, max_frames, parent=None):
+        super().__init__(parent)
+        self.start_year = start_year
+        self.end_year = end_year
+        self.step = step
+        self.max_frames = max_frames
+
+    def run(self):
+        """Fetch and filter the Wayback layer list off the UI thread."""
+        try:
+            layers = external_sources.fetch_esri_wayback_layers()
+            selected = external_sources.filter_esri_wayback_layers(
+                layers,
+                self.start_year,
+                self.end_year,
+                step=self.step,
+                max_frames=self.max_frames,
+            )
+            self.finished.emit(list(selected))
+        except Exception as exc:
+            self.error.emit(str(exc))
 
 
 class BboxMapTool(QgsMapToolEmitPoint):
@@ -1272,28 +1302,48 @@ class TimelapseDockWidget(QDockWidget):
 
     def refresh_esri_wayback_status(self):
         """Fetch the ESRI Wayback layer count for the selected year range."""
-        try:
-            layers = external_sources.fetch_esri_wayback_layers()
-            selected = external_sources.filter_esri_wayback_layers(
-                layers,
-                self.start_year.value(),
-                self.end_year.value(),
-                step=self.year_step.value(),
-                max_frames=(
-                    self.external_max_frames.value()
-                    if self.external_max_frames.value() > 0
-                    else None
-                ),
+        if getattr(self, "_esri_status_worker", None) is not None:
+            return
+
+        max_frames_value = self.external_max_frames.value()
+        worker = EsriWaybackStatusWorker(
+            start_year=self.start_year.value(),
+            end_year=self.end_year.value(),
+            step=self.year_step.value(),
+            max_frames=max_frames_value if max_frames_value > 0 else None,
+            parent=self,
+        )
+        worker.finished.connect(self._on_esri_status_finished)
+        worker.error.connect(self._on_esri_status_error)
+        worker.finished.connect(self._clear_esri_status_worker)
+        worker.error.connect(self._clear_esri_status_worker)
+
+        self._esri_status_worker = worker
+        self.esri_refresh_btn.setEnabled(False)
+        self.esri_status.setText("Fetching layer list...")
+        worker.start()
+
+    def _on_esri_status_finished(self, selected):
+        """Update the status label when the Wayback worker succeeds."""
+        if selected:
+            self.esri_status.setText(
+                f"{len(selected)} frames from {selected[0].date} "
+                f"to {selected[-1].date}"
             )
-            if selected:
-                self.esri_status.setText(
-                    f"{len(selected)} frames from {selected[0].date} "
-                    f"to {selected[-1].date}"
-                )
-            else:
-                self.esri_status.setText("No layers match the selected years.")
-        except Exception as e:
-            self.esri_status.setText(f"Failed to fetch layers: {e}")
+        else:
+            self.esri_status.setText("No layers match the selected years.")
+
+    def _on_esri_status_error(self, message):
+        """Surface a Wayback worker failure in the status label."""
+        self.esri_status.setText(f"Failed to fetch layers: {message}")
+
+    def _clear_esri_status_worker(self, *args):
+        """Re-enable the refresh button and forget the finished worker."""
+        self.esri_refresh_btn.setEnabled(True)
+        worker = getattr(self, "_esri_status_worker", None)
+        if worker is not None:
+            worker.deleteLater()
+        self._esri_status_worker = None
 
     def update_aoi_method(self):
         """Update AOI controls based on selected method."""

--- a/timelapse/dialogs/timelapse_dock.py
+++ b/timelapse/dialogs/timelapse_dock.py
@@ -50,7 +50,9 @@ from qgis.core import (
 )
 from qgis.gui import QgsMapToolEmitPoint, QgsRubberBand
 
-from ..core import timelapse_core
+from ..core import external_sources, timelapse_core
+
+EXTERNAL_IMAGERY_TYPES = {"ESRI Wayback", "Custom XYZ Template"}
 
 
 class TimelapseWorker(QThread):
@@ -72,6 +74,12 @@ class TimelapseWorker(QThread):
         """Execute the timelapse generation."""
         try:
             imagery_type = self.params.get("imagery_type", "Landsat")
+
+            if imagery_type in EXTERNAL_IMAGERY_TYPES:
+                result = self._run_external_timelapse(imagery_type)
+                self.progress.emit("Timelapse generation complete!")
+                self.finished.emit(result, self.params)
+                return
 
             # Check if EE is already initialized
             if not timelapse_core.is_ee_initialized():
@@ -246,11 +254,67 @@ class TimelapseWorker(QThread):
                 }
                 result = timelapse_core.create_goes_timelapse(**goes_params)
 
+            else:
+                raise ValueError(f"Unsupported imagery type: {imagery_type}")
+
             self.progress.emit("Timelapse generation complete!")
             self.finished.emit(result, self.params)
 
         except Exception as e:
             self.error.emit(str(e))
+
+    def _run_external_timelapse(self, imagery_type):
+        """Render external XYZ/WMTS imagery without Earth Engine."""
+        self.progress.emit(f"Preparing {imagery_type} frames...")
+
+        if imagery_type == "ESRI Wayback":
+            frames = external_sources.esri_wayback_frames(
+                start_year=self.params.get("start_year", 2014),
+                end_year=self.params.get("end_year", datetime.now().year),
+                step=self.params.get("step", 1),
+                max_frames=self.params.get("external_max_frames"),
+            )
+        else:
+            frames = external_sources.custom_xyz_frames(
+                template=self.params.get("custom_xyz_template", ""),
+                explicit_dates=self.params.get("custom_xyz_dates", ""),
+                start_year=self.params.get("start_year", datetime.now().year),
+                end_year=self.params.get("end_year", datetime.now().year),
+                start_date=self.params.get("start_date", "01-01"),
+                end_date=self.params.get("end_date", "12-31"),
+                frequency=self.params.get("frequency", "year"),
+                step=self.params.get("step", 1),
+            )
+
+        overlay_path = None
+        if self.params.get("add_overlay") and self.params.get("overlay_data"):
+            if self.params.get("overlay_source") != "local":
+                raise ValueError(
+                    "EE FeatureCollection overlays are only supported for "
+                    "Earth Engine imagery. Use a local vector overlay for "
+                    "external imagery sources."
+                )
+            overlay_path = self.params.get("overlay_data")
+
+        return external_sources.create_external_timelapse(
+            frames=frames,
+            bbox=self.params.get("bbox"),
+            out_gif=self.params.get("output_path"),
+            dimensions=self.params.get("dimensions", 768),
+            frames_per_second=self.params.get("fps", 5),
+            crs=self.params.get("crs", "EPSG:3857"),
+            title=self.params.get("title"),
+            add_text=self.params.get("add_text", True),
+            font_size=self.params.get("font_size", 20),
+            font_color=self.params.get("font_color", "white"),
+            add_progress_bar=self.params.get("add_progress_bar", True),
+            progress_bar_color=self.params.get("progress_bar_color", "white"),
+            progress_bar_height=self.params.get("progress_bar_height", 5),
+            loop=self.params.get("loop", 0),
+            mp4=self.params.get("create_mp4", False),
+            overlay_path=overlay_path,
+            progress_callback=self.progress.emit,
+        )
 
     def cancel(self):
         """Cancel the operation."""
@@ -387,22 +451,34 @@ class TimelapseDockWidget(QDockWidget):
         self.tabs.currentChanged.connect(self._on_tab_changed)
 
         layout.addWidget(self.tabs)
+        layout.addStretch(1)
 
         # Initialize imagery options after all tabs are created
         self.update_imagery_options()
 
         # Progress section
         progress_group = QGroupBox("Progress")
+        progress_group.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum
+        )
         progress_layout = QVBoxLayout()
-        progress_layout.setSpacing(4)
+        progress_layout.setSpacing(6)
+        progress_layout.setContentsMargins(8, 12, 8, 8)
 
         self.progress_bar = QProgressBar()
         self.progress_bar.setTextVisible(False)
-        self.progress_bar.setMaximumHeight(8)
+        self.progress_bar.setFixedHeight(8)
+        self.progress_bar.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
         progress_layout.addWidget(self.progress_bar)
 
         self.log_text = QTextEdit()
-        self.log_text.setMaximumHeight(80)
+        self.log_text.setMinimumHeight(72)
+        self.log_text.setMaximumHeight(180)
+        self.log_text.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
         self.log_text.setReadOnly(True)
         self.log_text.setFont(QFont("Monospace", 8))
         progress_layout.addWidget(self.log_text)
@@ -561,7 +637,7 @@ class TimelapseDockWidget(QDockWidget):
         layout.addWidget(extent_group)
 
         # GEE Project
-        gee_group = QGroupBox("Google Earth Engine")
+        self.gee_group = QGroupBox("Google Earth Engine")
         gee_layout = QFormLayout()
 
         self.gee_project_edit = QLineEdit()
@@ -582,8 +658,8 @@ class TimelapseDockWidget(QDockWidget):
             pass
         gee_layout.addRow("Project ID:", self.gee_project_edit)
 
-        gee_group.setLayout(gee_layout)
-        layout.addWidget(gee_group)
+        self.gee_group.setLayout(gee_layout)
+        layout.addWidget(self.gee_group)
 
         layout.addStretch()
         return widget
@@ -600,7 +676,16 @@ class TimelapseDockWidget(QDockWidget):
 
         self.imagery_type = QComboBox()
         self.imagery_type.addItems(
-            ["Landsat", "Sentinel-2", "Sentinel-1", "MODIS NDVI", "GOES", "NAIP"]
+            [
+                "Landsat",
+                "Sentinel-2",
+                "Sentinel-1",
+                "MODIS NDVI",
+                "GOES",
+                "NAIP",
+                "ESRI Wayback",
+                "Custom XYZ Template",
+            ]
         )
         self.imagery_type.setStyleSheet("font-size: 12px; padding: 4px;")
         type_layout.addWidget(self.imagery_type)
@@ -832,6 +917,49 @@ class TimelapseDockWidget(QDockWidget):
         self.goes_group.setLayout(goes_layout)
         layout.addWidget(self.goes_group)
 
+        # External imagery options
+        self.external_group = QGroupBox("External Source Options")
+        external_layout = QFormLayout()
+
+        self.esri_refresh_btn = QPushButton("Refresh Wayback Layers")
+        external_layout.addRow(self.esri_refresh_btn)
+
+        self.esri_status = QLabel("Layer list will be fetched when the timelapse runs.")
+        self.esri_status.setWordWrap(True)
+        external_layout.addRow("ESRI:", self.esri_status)
+        self.esri_status_label = external_layout.labelForField(self.esri_status)
+
+        self.external_max_frames = QSpinBox()
+        self.external_max_frames.setRange(0, 500)
+        self.external_max_frames.setValue(0)
+        self.external_max_frames.setSpecialValueText("All")
+        external_layout.addRow("Max frames:", self.external_max_frames)
+        self.external_max_frames_label = external_layout.labelForField(
+            self.external_max_frames
+        )
+
+        self.custom_xyz_template = QLineEdit()
+        self.custom_xyz_template.setPlaceholderText(
+            "https://.../{yyyy}_{MM}/.../{z}/{x}/{y}.png"
+        )
+        external_layout.addRow("URL template:", self.custom_xyz_template)
+        self.custom_xyz_template_label = external_layout.labelForField(
+            self.custom_xyz_template
+        )
+
+        self.custom_xyz_dates = QTextEdit()
+        self.custom_xyz_dates.setPlaceholderText(
+            "Optional dates, one YYYY-MM-DD per line"
+        )
+        self.custom_xyz_dates.setMaximumHeight(80)
+        external_layout.addRow("Dates:", self.custom_xyz_dates)
+        self.custom_xyz_dates_label = external_layout.labelForField(
+            self.custom_xyz_dates
+        )
+
+        self.external_group.setLayout(external_layout)
+        layout.addWidget(self.external_group)
+
         layout.addStretch()
         return widget
 
@@ -1031,6 +1159,7 @@ class TimelapseDockWidget(QDockWidget):
         self.cancel_button.clicked.connect(self.cancel_timelapse)
 
         self.imagery_type.currentIndexChanged.connect(self.update_imagery_options)
+        self.esri_refresh_btn.clicked.connect(self.refresh_esri_wayback_status)
         self.aoi_method.currentIndexChanged.connect(self.update_aoi_method)
 
         self.font_color_btn.clicked.connect(lambda: self.pick_color("font"))
@@ -1073,6 +1202,7 @@ class TimelapseDockWidget(QDockWidget):
     def update_imagery_options(self):
         """Show/hide imagery-specific options."""
         imagery = self.imagery_type.currentText()
+        is_external = imagery in EXTERNAL_IMAGERY_TYPES
 
         self.naip_group.setVisible(imagery == "NAIP")
         self.landsat_group.setVisible(imagery == "Landsat")
@@ -1080,11 +1210,23 @@ class TimelapseDockWidget(QDockWidget):
         self.s1_group.setVisible(imagery == "Sentinel-1")
         self.modis_group.setVisible(imagery == "MODIS NDVI")
         self.goes_group.setVisible(imagery == "GOES")
+        self.external_group.setVisible(is_external)
+        self.esri_refresh_btn.setVisible(imagery == "ESRI Wayback")
+        self.esri_status.setVisible(imagery == "ESRI Wayback")
+        self.esri_status_label.setVisible(imagery == "ESRI Wayback")
+        self.external_max_frames.setVisible(imagery == "ESRI Wayback")
+        self.external_max_frames_label.setVisible(imagery == "ESRI Wayback")
+        self.custom_xyz_template.setVisible(imagery == "Custom XYZ Template")
+        self.custom_xyz_template_label.setVisible(imagery == "Custom XYZ Template")
+        self.custom_xyz_dates.setVisible(imagery == "Custom XYZ Template")
+        self.custom_xyz_dates_label.setVisible(imagery == "Custom XYZ Template")
 
         # Show/hide date range controls based on imagery type
         # GOES uses its own datetime fields, not year range
         is_goes = imagery == "GOES"
         self.date_group.setVisible(not is_goes)
+        if hasattr(self, "gee_group"):
+            self.gee_group.setVisible(not is_external)
 
         # Update start year based on imagery
         if imagery == "NAIP":
@@ -1099,6 +1241,15 @@ class TimelapseDockWidget(QDockWidget):
         elif imagery == "MODIS NDVI":
             self.start_year.setMinimum(2000)
             self.start_year.setValue(2010)
+        elif imagery == "ESRI Wayback":
+            self.start_year.setMinimum(2014)
+            self.start_year.setValue(2014)
+            self.start_date.setText("01-01")
+            self.end_date.setText("12-31")
+            self.frequency.setCurrentText("day")
+        elif imagery == "Custom XYZ Template":
+            self.start_year.setMinimum(1900)
+            self.start_year.setValue(datetime.now().year)
 
         # Update output filename based on imagery type
         self.update_output_filename(imagery)
@@ -1112,10 +1263,37 @@ class TimelapseDockWidget(QDockWidget):
             "MODIS NDVI": "modis_ndvi_timelapse.gif",
             "GOES": "goes_timelapse.gif",
             "NAIP": "naip_timelapse.gif",
+            "ESRI Wayback": "esri_wayback_timelapse.gif",
+            "Custom XYZ Template": "custom_xyz_timelapse.gif",
         }
         filename = filename_map.get(imagery_type, "timelapse.gif")
         output_dir = os.path.join(os.path.expanduser("~"), "Downloads")
         self.output_path.setText(os.path.join(output_dir, filename))
+
+    def refresh_esri_wayback_status(self):
+        """Fetch the ESRI Wayback layer count for the selected year range."""
+        try:
+            layers = external_sources.fetch_esri_wayback_layers()
+            selected = external_sources.filter_esri_wayback_layers(
+                layers,
+                self.start_year.value(),
+                self.end_year.value(),
+                step=self.year_step.value(),
+                max_frames=(
+                    self.external_max_frames.value()
+                    if self.external_max_frames.value() > 0
+                    else None
+                ),
+            )
+            if selected:
+                self.esri_status.setText(
+                    f"{len(selected)} frames from {selected[0].date} "
+                    f"to {selected[-1].date}"
+                )
+            else:
+                self.esri_status.setText("No layers match the selected years.")
+        except Exception as e:
+            self.esri_status.setText(f"Failed to fetch layers: {e}")
 
     def update_aoi_method(self):
         """Update AOI controls based on selected method."""
@@ -1368,6 +1546,22 @@ class TimelapseDockWidget(QDockWidget):
             )
             return False
 
+        if self.imagery_type.currentText() == "Custom XYZ Template":
+            if not self.custom_xyz_template.text().strip():
+                QMessageBox.warning(
+                    self,
+                    "Invalid Input",
+                    "Please specify a custom XYZ URL template.",
+                )
+                return False
+            try:
+                external_sources.parse_explicit_dates(
+                    self.custom_xyz_dates.toPlainText()
+                )
+            except ValueError as e:
+                QMessageBox.warning(self, "Invalid Input", str(e))
+                return False
+
         return True
 
     def get_naip_bands(self):
@@ -1483,6 +1677,14 @@ class TimelapseDockWidget(QDockWidget):
             "goes_custom_blue": self.goes_blue_band.currentText(),
             "goes_start_datetime": self.goes_start_datetime.text(),
             "goes_end_datetime": self.goes_end_datetime.text(),
+            # External imagery
+            "external_max_frames": (
+                self.external_max_frames.value()
+                if self.external_max_frames.value() > 0
+                else None
+            ),
+            "custom_xyz_template": self.custom_xyz_template.text(),
+            "custom_xyz_dates": self.custom_xyz_dates.toPlainText(),
             # Visualization
             "add_text": self.add_text.isChecked(),
             "font_size": self.font_size.value(),
@@ -1492,6 +1694,7 @@ class TimelapseDockWidget(QDockWidget):
             "progress_bar_height": self.progress_height.value(),
             "title": self.title_text.text() or None,
             "create_mp4": self.create_mp4.isChecked(),
+            "loop": self.loop_count.value(),
             # Vector Overlay
             "add_overlay": self.add_overlay.isChecked(),
             "overlay_source": (


### PR DESCRIPTION
## Summary
- Add ESRI Wayback WMTS and custom XYZ template imagery sources that render through QGIS without requiring Earth Engine, including dock UI wiring and the supporting worker path.
- Harden the new HTTP/XML code so the bandit pre-commit hook stays clean: a _require_https helper guards urlopen (B310), and ElementTree usage carries justified suppressions (B405/B314) since input is parsed from a fixed trusted https endpoint.
- Add unit tests covering capabilities parsing, layer filtering, URL/template expansion, explicit date parsing, and the external worker dispatch path.

## Test plan
- [x] pre-commit run --all-files (black, codespell, bandit, ...)
- [x] pytest tests/test_external_sources.py tests/test_external_worker.py
- [ ] Smoke-test the new ESRI Wayback and Custom XYZ Template options in the QGIS plugin dock