### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -2,8 +2,8 @@
 name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
-description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, and MODIS NDVI) using Google Earth Engine
-version=0.10.6
+description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, MODIS NDVI, ESRI Wayback, and custom XYZ sources)
+version=0.11.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -33,6 +33,10 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.11.0:
+        - Add ESRI Wayback and custom XYZ template timelapse sources without requiring Earth Engine initialization
+        - Filter black and duplicate external imagery frames and report kept/skipped frame counts
+        - Improve Progress section layout and apply output FPS to external-source GIFs
     0.10.6:
         - Shrink the timelapse dock's tab area to the current tab's content so the AOI / Output / Style tabs no longer leave a visible gap above the Progress section
         - Reorder Settings -> Earth Engine actions so Authenticate appears above Initialize


### PR DESCRIPTION
## Summary
- Bump plugin version to 0.11.0 and update the description to mention the new ESRI Wayback and custom XYZ sources
- Add a 0.11.0 changelog entry covering the external imagery sources, black/duplicate frame filtering, Progress section layout, and FPS application to external-source GIFs

## Test plan
- [ ] Install the built plugin from the new tag in QGIS and confirm the version shows as 0.11.0
- [ ] Verify the plugin loads on QGIS 3.28+ and the Timelapse dock opens without errors
- [ ] Run a short ESRI Wayback or custom XYZ timelapse and confirm frames are produced and the GIF respects the configured FPS