### PR TITLE
Fix macOS QGIS dependency installer

### DIFF
--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -291,9 +291,25 @@ def _is_python_executable_name(path: str) -> bool:
     )
 
 
+def _is_macos_qgis_app_bundle_python(path: str) -> bool:
+    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    if not (platform.system() == "Darwin" or sys.platform == "darwin"):
+        return False
+    parts = os.path.abspath(path).split(os.sep)
+    for idx, part in enumerate(parts):
+        lower = part.lower()
+        if not (lower.startswith("qgis") and lower.endswith(".app")):
+            continue
+        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+    return False
+
+
 def _python_candidate_matches_runtime(path: str) -> bool:
     """Return True when a candidate is executable and matches QGIS Python."""
     if not path or not os.path.isfile(path) or not _is_python_executable_name(path):
+        return False
+
+    if _is_macos_qgis_app_bundle_python(path):
         return False
     try:
         result = subprocess.run(  # nosec B603
@@ -506,8 +522,14 @@ def create_venv(venv_dir=None, progress_callback=None):
     if progress_callback:
         progress_callback(10, "Creating virtual environment...")
 
-    system_python = _get_system_python()
-    _log(f"Using Python: {system_python}")
+    system_python = None
+    python_lookup_error = ""
+    try:
+        system_python = _get_system_python()
+    except RuntimeError as exc:
+        python_lookup_error = str(exc)
+    if system_python:
+        _log(f"Using Python: {system_python}")
 
     from .uv_manager import uv_exists, get_uv_path
 
@@ -515,9 +537,15 @@ def create_venv(venv_dir=None, progress_callback=None):
 
     if use_uv:
         uv_path = get_uv_path()
-        cmd = [uv_path, "venv", "--python", system_python, venv_dir]
+        uv_python = system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        cmd = [uv_path, "venv"]
+        if system_python is None:
+            cmd.append("--managed-python")
+        cmd += ["--python", uv_python, venv_dir]
         _log("Creating venv with uv")
     else:
+        if system_python is None:
+            return False, python_lookup_error
         cmd = [system_python, "-m", "venv", venv_dir]
         _log("Creating venv with stdlib venv")
 

--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -537,7 +537,9 @@ def create_venv(venv_dir=None, progress_callback=None):
 
     if use_uv:
         uv_path = get_uv_path()
-        uv_python = system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        uv_python = (
+            system_python or f"{sys.version_info.major}.{sys.version_info.minor}"
+        )
         cmd = [uv_path, "venv"]
         if system_python is None:
             cmd.append("--managed-python")

--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -292,7 +292,7 @@ def _is_python_executable_name(path: str) -> bool:
 
 
 def _is_macos_qgis_app_bundle_python(path: str) -> bool:
-    """Return True for Python binaries inside a QGIS macOS .app bundle."""
+    """Return True for unsafe Python launchers in QGIS.app/Contents/MacOS."""
     if not (platform.system() == "Darwin" or sys.platform == "darwin"):
         return False
     parts = os.path.abspath(path).split(os.sep)
@@ -300,7 +300,12 @@ def _is_macos_qgis_app_bundle_python(path: str) -> bool:
         lower = part.lower()
         if not (lower.startswith("qgis") and lower.endswith(".app")):
             continue
-        return idx + 1 < len(parts) and parts[idx + 1] == "Contents"
+        if idx + 2 >= len(parts):
+            return False
+        if parts[idx + 1].lower() != "contents" or parts[idx + 2].lower() != "macos":
+            return False
+        name = os.path.basename(path).lower()
+        return name.startswith("qgis") or _is_python_executable_name(path)
     return False
 
 
@@ -528,6 +533,12 @@ def create_venv(venv_dir=None, progress_callback=None):
         system_python = _get_system_python()
     except RuntimeError as exc:
         python_lookup_error = str(exc)
+    if python_lookup_error and system_python is None:
+        _log(
+            "Python lookup failed; falling back to uv-managed Python if "
+            f"available: {python_lookup_error}",
+            Qgis.MessageLevel.Warning,
+        )
     if system_python:
         _log(f"Using Python: {system_python}")
 
@@ -626,10 +637,12 @@ def create_venv(venv_dir=None, progress_callback=None):
         _cleanup_partial_venv(venv_dir)
         return False, "Virtual environment creation timed out"
     except FileNotFoundError:
+        missing_executable = cmd[0] if cmd else system_python
         _log(
-            f"Python executable not found: {system_python}", Qgis.MessageLevel.Critical
+            f"Venv creation executable not found: {missing_executable}",
+            Qgis.MessageLevel.Critical,
         )
-        return False, f"Python not found: {system_python}"
+        return False, f"Executable not found: {missing_executable}"
     except Exception as e:
         _log(f"Exception during venv creation: {str(e)}", Qgis.MessageLevel.Critical)
         _cleanup_partial_venv(venv_dir)

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -32,7 +32,7 @@ icon=icons/icon.png
 experimental=False
 deprecated=False
 
-changelog=
+changelog=Fix macOS QGIS installer dependency installation and bump patch version.
     0.11.0:
         - Add ESRI Wayback and custom XYZ template timelapse sources without requiring Earth Engine initialization
         - Filter black and duplicate external imagery frames and report kept/skipped frame counts

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -32,7 +32,9 @@ icon=icons/icon.png
 experimental=False
 deprecated=False
 
-changelog=Fix macOS QGIS installer dependency installation and bump patch version.
+changelog=
+    0.11.1:
+        - Fix macOS QGIS installer dependency installation
     0.11.0:
         - Add ESRI Wayback and custom XYZ template timelapse sources without requiring Earth Engine initialization
         - Filter black and duplicate external imagery frames and report kept/skipped frame counts

--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -3,7 +3,7 @@ name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, MODIS NDVI, ESRI Wayback, and custom XYZ sources)
-version=0.11.0
+version=0.11.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 


### PR DESCRIPTION
## Summary
- Reject macOS QGIS app-bundle Python wrappers for dependency virtual environment creation where this plugin manages dependency venvs.
- Use uv-managed Python when no safe local Python interpreter is available.
- Bump the QGIS plugin patch version in `metadata.txt`.

## Root Cause
Official macOS QGIS installer builds can expose Python wrappers inside `QGIS*.app/Contents/MacOS` that either fail to start outside QGIS or create virtual environments pointing at the QGIS CI build prefix. Those venvs fail during dependency installation with missing stdlib modules such as `encodings`.

## Validation
- `python -m py_compile timelapse/core/venv_manager.py`
- Focused local QGIS plugin tests were run from the source checkout before publishing these PRs.
