### PR TITLE
Fix recurring dependency status check

### DIFF
--- a/tests/test_venv_manager.py
+++ b/tests/test_venv_manager.py
@@ -56,6 +56,39 @@ def test_get_venv_status_accepts_pillow_import_and_lowercase_dist_info(
     assert venv_manager.get_venv_status() == (True, "Virtual environment ready")
 
 
+def test_get_venv_status_accepts_ready_venv_without_standalone_python(
+    tmp_path, monkeypatch
+):
+    """A ready venv remains valid if it was created without standalone Python."""
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+
+    _write_dist_info(
+        site_packages,
+        "earthengine_api-1.7.4.dist-info",
+        "earthengine-api",
+        "1.7.4",
+    )
+    _write_dist_info(site_packages, "numpy-2.3.5.dist-info", "numpy", "2.3.5")
+    _write_dist_info(site_packages, "pillow-12.1.1.dist-info", "Pillow", "12.1.1")
+    _write_dist_info(
+        site_packages,
+        "google_auth_oauthlib-1.2.3.dist-info",
+        "google-auth-oauthlib",
+        "1.2.3",
+    )
+
+    monkeypatch.setattr(python_manager, "standalone_python_exists", lambda: False)
+    monkeypatch.setattr(venv_manager, "venv_exists", lambda venv_dir=None: True)
+    monkeypatch.setattr(
+        venv_manager,
+        "get_venv_site_packages",
+        lambda venv_dir=None: str(site_packages),
+    )
+
+    assert venv_manager.get_venv_status() == (True, "Virtual environment ready")
+
+
 def test_check_dependencies_reports_versions_from_venv_site_packages(
     tmp_path, monkeypatch
 ):

--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -1170,7 +1170,7 @@ def get_venv_status():
         A tuple of (is_ready: bool, message: str).
     """
     if not venv_exists():
-        return False, "Dependencies not installed"
+        return False, "Virtual environment not configured"
 
     site_packages = get_venv_site_packages()
     if site_packages is None:

--- a/timelapse/core/venv_manager.py
+++ b/timelapse/core/venv_manager.py
@@ -1169,13 +1169,8 @@ def get_venv_status():
     Returns:
         A tuple of (is_ready: bool, message: str).
     """
-    from .python_manager import standalone_python_exists
-
-    if not standalone_python_exists():
-        return False, "Dependencies not installed"
-
     if not venv_exists():
-        return False, "Virtual environment not configured"
+        return False, "Dependencies not installed"
 
     site_packages = get_venv_site_packages()
     if site_packages is None:


### PR DESCRIPTION
## Summary
- Treat an existing plugin virtual environment as the source of truth for dependency readiness
- Avoid marking installed dependencies as missing just because the standalone installer Python is absent
- Add a regression test for a ready venv created through the fallback Python path

## Root cause
`get_venv_status()` required the standalone Python download to exist before checking the actual venv. When dependencies were installed through a fallback Python path, the plugin worked in the current QGIS session but reported missing dependencies after restart.

## Tests
- `pre-commit run --all-files`
- `pytest tests/test_venv_manager.py`
- `pytest`

Closes #61