### PR TITLE
chore: bump version to 0.11.2

### DIFF
--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -3,7 +3,7 @@ name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, MODIS NDVI, ESRI Wayback, and custom XYZ sources)
-version=0.11.1
+version=0.11.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 


### PR DESCRIPTION
## Summary
- Bump plugin version from 0.11.1 to 0.11.2 in timelapse/metadata.txt

## Test plan
- [ ] Verify the plugin loads in QGIS and the About dialog shows version 0.11.2