### PR TITLE
Add dekadal and weekly timestep support

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ qgis-timelapse-plugin/
 | Imagery Type     | NAIP, Landsat, Sentinel-2, Sentinel-1, MODIS NDVI, or GOES |
 | Start/End Year   | Temporal range for the timelapse                           |
 | Start/End Date   | Seasonal filter (MM-dd format)                             |
-| Frequency        | Year, quarter, month, dekadal, or day composites           |
+| Frequency        | Year, quarter, month, dekadal, week, or day composites     |
 | Year Step        | Interval between frames                                    |
 | Band Combination | Visualization bands                                        |
 | Max Cloud %      | Cloud coverage threshold (Sentinel-2)                      |

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ qgis-timelapse-plugin/
 | Imagery Type     | NAIP, Landsat, Sentinel-2, Sentinel-1, MODIS NDVI, or GOES |
 | Start/End Year   | Temporal range for the timelapse                           |
 | Start/End Date   | Seasonal filter (MM-dd format)                             |
+| Frequency        | Year, quarter, month, dekadal, or day composites           |
 | Year Step        | Interval between frames                                    |
 | Band Combination | Visualization bands                                        |
 | Max Cloud %      | Cloud coverage threshold (Sentinel-2)                      |

--- a/tests/test_timelapse_core.py
+++ b/tests/test_timelapse_core.py
@@ -1,0 +1,65 @@
+import datetime
+
+from timelapse.core import timelapse_core
+
+
+def test_date_sequence_dekadal_uses_calendar_dekads():
+    ranges = timelapse_core.date_sequence(
+        start_year=2026,
+        end_year=2026,
+        start_date="01-01",
+        end_date="01-31",
+        frequency="dekadal",
+        step=1,
+    )
+
+    assert ranges == [
+        (
+            datetime.date(2026, 1, 1),
+            datetime.date(2026, 1, 10),
+            "2026-01-01",
+        ),
+        (
+            datetime.date(2026, 1, 11),
+            datetime.date(2026, 1, 20),
+            "2026-01-11",
+        ),
+        (
+            datetime.date(2026, 1, 21),
+            datetime.date(2026, 1, 31),
+            "2026-01-21",
+        ),
+    ]
+
+
+def test_date_sequence_dekadal_respects_step():
+    ranges = timelapse_core.date_sequence(
+        start_year=2026,
+        end_year=2026,
+        start_date="01-01",
+        end_date="01-31",
+        frequency="dekadal",
+        step=2,
+    )
+
+    assert [label for _start, _end, label in ranges] == [
+        "2026-01-01",
+        "2026-01-21",
+    ]
+
+
+def test_date_sequence_dekadal_uses_actual_month_end():
+    ranges = timelapse_core.date_sequence(
+        start_year=2026,
+        end_year=2026,
+        start_date="02-01",
+        end_date="02-28",
+        frequency="dekadal",
+        step=1,
+    )
+
+    assert ranges[-1] == (
+        datetime.date(2026, 2, 21),
+        datetime.date(2026, 2, 28),
+        "2026-02-21",
+    )

--- a/tests/test_timelapse_core.py
+++ b/tests/test_timelapse_core.py
@@ -3,6 +3,52 @@ import datetime
 from timelapse.core import timelapse_core
 
 
+def test_date_sequence_week_uses_seven_day_ranges_with_clipped_end():
+    ranges = timelapse_core.date_sequence(
+        start_year=2026,
+        end_year=2026,
+        start_date="01-01",
+        end_date="01-20",
+        frequency="week",
+        step=1,
+    )
+
+    assert ranges == [
+        (
+            datetime.date(2026, 1, 1),
+            datetime.date(2026, 1, 7),
+            "2026-01-01",
+        ),
+        (
+            datetime.date(2026, 1, 8),
+            datetime.date(2026, 1, 14),
+            "2026-01-08",
+        ),
+        (
+            datetime.date(2026, 1, 15),
+            datetime.date(2026, 1, 20),
+            "2026-01-15",
+        ),
+    ]
+
+
+def test_date_sequence_week_respects_step():
+    ranges = timelapse_core.date_sequence(
+        start_year=2026,
+        end_year=2026,
+        start_date="01-01",
+        end_date="01-31",
+        frequency="week",
+        step=2,
+    )
+
+    assert [label for _start, _end, label in ranges] == [
+        "2026-01-01",
+        "2026-01-15",
+        "2026-01-29",
+    ]
+
+
 def test_date_sequence_dekadal_uses_calendar_dekads():
     ranges = timelapse_core.date_sequence(
         start_year=2026,

--- a/timelapse/core/timelapse_core.py
+++ b/timelapse/core/timelapse_core.py
@@ -574,7 +574,8 @@ def date_sequence(
         end_year: Ending year.
         start_date: Start date within year (MM-dd).
         end_date: End date within year (MM-dd).
-        frequency: Temporal frequency ('year', 'quarter', 'month', 'day').
+        frequency: Temporal frequency ('year', 'quarter', 'month',
+            'dekadal', 'day').
         step: Step size.
 
     Returns:
@@ -670,6 +671,47 @@ def date_sequence(
                 label = f"{year}-{month:02d}"
                 dates.append((month_start, month_end, label))
 
+    elif frequency == "dekadal":
+        selected_count = 0
+        for year in range(start_year, end_year + 1):
+            for month in range(1, 13):
+                if month == 12:
+                    month_end_day = 31
+                else:
+                    month_end_day = (date(year, month + 1, 1) - timedelta(days=1)).day
+
+                dekads = [(1, 10), (11, 20), (21, month_end_day)]
+                for dekad_start_day, dekad_end_day in dekads:
+                    dekad_start = date(year, month, dekad_start_day)
+                    dekad_end = date(year, month, dekad_end_day)
+
+                    if start_month <= end_month:
+                        seasonal_ranges = [
+                            (
+                                date(year, start_month, start_day),
+                                date(year, end_month, end_day),
+                            )
+                        ]
+                    else:
+                        seasonal_ranges = [
+                            (
+                                date(year - 1, start_month, start_day),
+                                date(year, end_month, end_day),
+                            ),
+                            (
+                                date(year, start_month, start_day),
+                                date(year + 1, end_month, end_day),
+                            ),
+                        ]
+
+                    for season_start, season_end in seasonal_ranges:
+                        if dekad_end >= season_start and dekad_start <= season_end:
+                            if selected_count % step == 0:
+                                label = dekad_start.strftime("%Y-%m-%d")
+                                dates.append((dekad_start, dekad_end, label))
+                            selected_count += 1
+                            break
+
     elif frequency == "day":
         current = date(start_year, start_month, start_day)
         end = date(end_year, end_month, end_day)
@@ -701,7 +743,7 @@ def create_timeseries(
         end_date: End date in 'YYYY-MM-dd' format.
         region: Region of interest.
         bands: List of band names.
-        frequency: Temporal frequency ('year', 'month', 'day').
+        frequency: Temporal frequency ('year', 'month', 'dekadal', 'day').
         reducer: Reducer type ('median', 'mean', 'min', 'max').
         date_format: Output date format.
         drop_empty: Whether to drop empty images.
@@ -733,6 +775,7 @@ def create_timeseries(
         date_formats = {
             "year": "YYYY",
             "month": "YYYY-MM",
+            "dekadal": "YYYY-MM-dd",
             "day": "YYYY-MM-dd",
         }
         date_format = date_formats.get(frequency, "YYYY-MM-dd")
@@ -744,9 +787,15 @@ def create_timeseries(
     freq_units = {
         "year": "year",
         "month": "month",
+        "dekadal": "day",
         "day": "day",
     }
     unit = freq_units.get(frequency, "year")
+    sequence_step = step
+    period_step = 1
+    if frequency == "dekadal":
+        sequence_step = step * 10
+        period_step = 10
 
     # Generate sequence of dates
     def get_sequence(start, end, unit, step):
@@ -754,11 +803,11 @@ def create_timeseries(
         sequence = ee.List.sequence(0, diff.subtract(1), step)
         return sequence.map(lambda n: start.advance(n, unit))
 
-    dates = get_sequence(start, end, unit, step)
+    dates = get_sequence(start, end, unit, sequence_step)
 
     def aggregate_images(date):
         date = ee.Date(date)
-        end_date = date.advance(1, unit)
+        end_date = date.advance(period_step, unit)
         filtered = collection.filterDate(date, end_date)
 
         if region is not None:
@@ -869,7 +918,8 @@ def sentinel2_timeseries(
         bands: List of bands to include.
         apply_fmask: Whether to apply cloud masking.
         cloud_pct: Maximum cloud percentage.
-        frequency: Temporal frequency ('year', 'quarter', 'month', 'day').
+        frequency: Temporal frequency ('year', 'quarter', 'month',
+            'dekadal', 'day').
         reducer: Reducer type.
         step: Step size.
 
@@ -976,7 +1026,8 @@ def sentinel1_timeseries(
         end_date: End date within year (MM-dd).
         bands: List of bands (VV, VH, HH, HV).
         orbit: Orbit direction ('ascending', 'descending', or both).
-        frequency: Temporal frequency ('year', 'quarter', 'month', 'day').
+        frequency: Temporal frequency ('year', 'quarter', 'month',
+            'dekadal', 'day').
         reducer: Reducer type.
         step: Step size.
 
@@ -1053,7 +1104,8 @@ def landsat_timeseries(
         start_date: Start date within year (MM-dd).
         end_date: End date within year (MM-dd).
         apply_fmask: Whether to apply cloud/shadow masking.
-        frequency: Temporal frequency ('year', 'quarter', 'month', 'day').
+        frequency: Temporal frequency ('year', 'quarter', 'month',
+            'dekadal', 'day').
         step: Step size.
 
     Returns:
@@ -1616,7 +1668,8 @@ def create_sentinel2_timelapse(
         progress_bar_height: Progress bar height.
         loop: Loop count.
         mp4: Whether to also create MP4.
-        frequency: Temporal frequency ('year', 'quarter', 'month', 'day').
+        frequency: Temporal frequency ('year', 'quarter', 'month',
+            'dekadal', 'day').
         step: Step size.
 
     Returns:
@@ -1782,7 +1835,8 @@ def create_sentinel1_timelapse(
         progress_bar_height: Progress bar height.
         loop: Loop count.
         mp4: Whether to also create MP4.
-        frequency: Temporal frequency ('year', 'quarter', 'month', 'day').
+        frequency: Temporal frequency ('year', 'quarter', 'month',
+            'dekadal', 'day').
         step: Step size.
 
     Returns:
@@ -1945,7 +1999,8 @@ def create_landsat_timelapse(
         progress_bar_height: Progress bar height.
         loop: Loop count.
         mp4: Whether to also create MP4.
-        frequency: Temporal frequency ('year', 'quarter', 'month', 'day').
+        frequency: Temporal frequency ('year', 'quarter', 'month',
+            'dekadal', 'day').
         step: Step size.
 
     Returns:

--- a/timelapse/core/timelapse_core.py
+++ b/timelapse/core/timelapse_core.py
@@ -575,7 +575,7 @@ def date_sequence(
         start_date: Start date within year (MM-dd).
         end_date: End date within year (MM-dd).
         frequency: Temporal frequency ('year', 'quarter', 'month',
-            'dekadal', 'day').
+            'dekadal', 'week', 'day').
         step: Step size.
 
     Returns:
@@ -671,6 +671,39 @@ def date_sequence(
                 label = f"{year}-{month:02d}"
                 dates.append((month_start, month_end, label))
 
+    elif frequency == "week":
+        selected_count = 0
+        for year in range(start_year, end_year + 1):
+            if start_month <= end_month:
+                seasonal_ranges = [
+                    (
+                        date(year, start_month, start_day),
+                        date(year, end_month, end_day),
+                    )
+                ]
+            else:
+                seasonal_ranges = [
+                    (
+                        date(year - 1, start_month, start_day),
+                        date(year, end_month, end_day),
+                    ),
+                    (
+                        date(year, start_month, start_day),
+                        date(year + 1, end_month, end_day),
+                    ),
+                ]
+
+            for season_start, season_end in seasonal_ranges:
+                current = max(season_start, date(year, 1, 1))
+                clipped_end = min(season_end, date(year, 12, 31))
+                while current <= clipped_end:
+                    week_end = min(current + timedelta(days=6), clipped_end)
+                    if selected_count % step == 0:
+                        label = current.strftime("%Y-%m-%d")
+                        dates.append((current, week_end, label))
+                    selected_count += 1
+                    current += timedelta(days=7)
+
     elif frequency == "dekadal":
         selected_count = 0
         for year in range(start_year, end_year + 1):
@@ -743,7 +776,8 @@ def create_timeseries(
         end_date: End date in 'YYYY-MM-dd' format.
         region: Region of interest.
         bands: List of band names.
-        frequency: Temporal frequency ('year', 'month', 'dekadal', 'day').
+        frequency: Temporal frequency ('year', 'month', 'dekadal',
+            'week', 'day').
         reducer: Reducer type ('median', 'mean', 'min', 'max').
         date_format: Output date format.
         drop_empty: Whether to drop empty images.
@@ -776,6 +810,7 @@ def create_timeseries(
             "year": "YYYY",
             "month": "YYYY-MM",
             "dekadal": "YYYY-MM-dd",
+            "week": "YYYY-MM-dd",
             "day": "YYYY-MM-dd",
         }
         date_format = date_formats.get(frequency, "YYYY-MM-dd")
@@ -788,6 +823,7 @@ def create_timeseries(
         "year": "year",
         "month": "month",
         "dekadal": "day",
+        "week": "week",
         "day": "day",
     }
     unit = freq_units.get(frequency, "year")
@@ -919,7 +955,7 @@ def sentinel2_timeseries(
         apply_fmask: Whether to apply cloud masking.
         cloud_pct: Maximum cloud percentage.
         frequency: Temporal frequency ('year', 'quarter', 'month',
-            'dekadal', 'day').
+            'dekadal', 'week', 'day').
         reducer: Reducer type.
         step: Step size.
 
@@ -1027,7 +1063,7 @@ def sentinel1_timeseries(
         bands: List of bands (VV, VH, HH, HV).
         orbit: Orbit direction ('ascending', 'descending', or both).
         frequency: Temporal frequency ('year', 'quarter', 'month',
-            'dekadal', 'day').
+            'dekadal', 'week', 'day').
         reducer: Reducer type.
         step: Step size.
 
@@ -1105,7 +1141,7 @@ def landsat_timeseries(
         end_date: End date within year (MM-dd).
         apply_fmask: Whether to apply cloud/shadow masking.
         frequency: Temporal frequency ('year', 'quarter', 'month',
-            'dekadal', 'day').
+            'dekadal', 'week', 'day').
         step: Step size.
 
     Returns:
@@ -1669,7 +1705,7 @@ def create_sentinel2_timelapse(
         loop: Loop count.
         mp4: Whether to also create MP4.
         frequency: Temporal frequency ('year', 'quarter', 'month',
-            'dekadal', 'day').
+            'dekadal', 'week', 'day').
         step: Step size.
 
     Returns:
@@ -1836,7 +1872,7 @@ def create_sentinel1_timelapse(
         loop: Loop count.
         mp4: Whether to also create MP4.
         frequency: Temporal frequency ('year', 'quarter', 'month',
-            'dekadal', 'day').
+            'dekadal', 'week', 'day').
         step: Step size.
 
     Returns:
@@ -2000,7 +2036,7 @@ def create_landsat_timelapse(
         loop: Loop count.
         mp4: Whether to also create MP4.
         frequency: Temporal frequency ('year', 'quarter', 'month',
-            'dekadal', 'day').
+            'dekadal', 'week', 'day').
         step: Step size.
 
     Returns:

--- a/timelapse/core/timelapse_core.py
+++ b/timelapse/core/timelapse_core.py
@@ -815,36 +815,12 @@ def create_timeseries(
         }
         date_format = date_formats.get(frequency, "YYYY-MM-dd")
 
-    # Create date sequence
-    start = ee.Date(start_date)
-    end = ee.Date(end_date)
-
-    freq_units = {
-        "year": "year",
-        "month": "month",
-        "dekadal": "day",
-        "week": "week",
-        "day": "day",
-    }
-    unit = freq_units.get(frequency, "year")
-    sequence_step = step
-    period_step = 1
-    if frequency == "dekadal":
-        sequence_step = step * 10
-        period_step = 10
-
-    # Generate sequence of dates
-    def get_sequence(start, end, unit, step):
-        diff = end.difference(start, unit).round()
-        sequence = ee.List.sequence(0, diff.subtract(1), step)
-        return sequence.map(lambda n: start.advance(n, unit))
-
-    dates = get_sequence(start, end, unit, sequence_step)
-
-    def aggregate_images(date):
-        date = ee.Date(date)
-        end_date = date.advance(period_step, unit)
-        filtered = collection.filterDate(date, end_date)
+    # Aggregate every image whose timestamp falls in [period_start, period_end)
+    # into a single composite, tagged with the period start date.
+    def aggregate_images(period_start, period_end):
+        period_start = ee.Date(period_start)
+        period_end = ee.Date(period_end)
+        filtered = collection.filterDate(period_start, period_end)
 
         if region is not None:
             reduced = filtered.reduce(selected_reducer).clip(region)
@@ -853,13 +829,82 @@ def create_timeseries(
 
         return reduced.set(
             {
-                "system:time_start": date.millis(),
-                "system:date": date.format(date_format),
+                "system:time_start": period_start.millis(),
+                "system:date": period_start.format(date_format),
                 "empty": filtered.size().eq(0),
             }
         )
 
-    result = ee.ImageCollection(dates.map(aggregate_images))
+    if frequency == "dekadal":
+        # Build calendar dekads (1-10, 11-20, 21-end of month) rather than
+        # fixed 10-day windows from start_date, so the generated timestamps
+        # stay aligned to month boundaries (matching date_sequence()).
+        from datetime import date as _date
+
+        start_dt = datetime.datetime.strptime(start_date, "%Y-%m-%d").date()
+        end_dt = datetime.datetime.strptime(end_date, "%Y-%m-%d").date()
+
+        dekad_ranges = []
+        selected_count = 0
+        for year in range(start_dt.year, end_dt.year + 1):
+            for month in range(1, 13):
+                for dekad_start_day in (1, 11, 21):
+                    dekad_start = _date(year, month, dekad_start_day)
+                    # Exclusive upper bound: the start of the next dekad.
+                    if dekad_start_day == 1:
+                        dekad_stop = _date(year, month, 11)
+                    elif dekad_start_day == 11:
+                        dekad_stop = _date(year, month, 21)
+                    elif month == 12:
+                        dekad_stop = _date(year + 1, 1, 1)
+                    else:
+                        dekad_stop = _date(year, month + 1, 1)
+
+                    # Keep dekads overlapping the requested [start, end] range.
+                    if dekad_stop > start_dt and dekad_start <= end_dt:
+                        if selected_count % step == 0:
+                            dekad_ranges.append(
+                                [dekad_start.isoformat(), dekad_stop.isoformat()]
+                            )
+                        selected_count += 1
+
+        dekads = ee.List(dekad_ranges)
+        result = ee.ImageCollection(
+            dekads.map(
+                lambda pair: aggregate_images(
+                    ee.List(pair).get(0), ee.List(pair).get(1)
+                )
+            )
+        )
+
+        if drop_empty:
+            result = result.filterMetadata("empty", "equals", 0)
+
+        return result
+
+    # Create date sequence for fixed-width frequencies.
+    start = ee.Date(start_date)
+    end = ee.Date(end_date)
+
+    freq_units = {
+        "year": "year",
+        "month": "month",
+        "week": "week",
+        "day": "day",
+    }
+    unit = freq_units.get(frequency, "year")
+
+    # Generate sequence of dates
+    def get_sequence(start, end, unit, step):
+        diff = end.difference(start, unit).round()
+        sequence = ee.List.sequence(0, diff.subtract(1), step)
+        return sequence.map(lambda n: start.advance(n, unit))
+
+    dates = get_sequence(start, end, unit, step)
+
+    result = ee.ImageCollection(
+        dates.map(lambda d: aggregate_images(d, ee.Date(d).advance(1, unit)))
+    )
 
     if drop_empty:
         result = result.filterMetadata("empty", "equals", 0)

--- a/timelapse/dialogs/timelapse_dock.py
+++ b/timelapse/dialogs/timelapse_dock.py
@@ -767,12 +767,13 @@ class TimelapseDockWidget(QDockWidget):
         freq_layout.setContentsMargins(0, 0, 0, 0)
         freq_layout.addWidget(QLabel("Frequency:"))
         self.frequency = QComboBox()
-        self.frequency.addItems(["year", "quarter", "month", "day"])
+        self.frequency.addItems(["year", "quarter", "month", "dekadal", "day"])
         self.frequency.setToolTip(
             "Temporal frequency for compositing:\n"
             "• year: One composite per year\n"
             "• quarter: One composite per quarter (3 months)\n"
             "• month: One composite per month\n"
+            "• dekadal: Three composites per month (1-10, 11-20, 21-end)\n"
             "• day: Daily composites (more data intensive)"
         )
         freq_layout.addWidget(self.frequency)

--- a/timelapse/dialogs/timelapse_dock.py
+++ b/timelapse/dialogs/timelapse_dock.py
@@ -767,13 +767,14 @@ class TimelapseDockWidget(QDockWidget):
         freq_layout.setContentsMargins(0, 0, 0, 0)
         freq_layout.addWidget(QLabel("Frequency:"))
         self.frequency = QComboBox()
-        self.frequency.addItems(["year", "quarter", "month", "dekadal", "day"])
+        self.frequency.addItems(["year", "quarter", "month", "dekadal", "week", "day"])
         self.frequency.setToolTip(
             "Temporal frequency for compositing:\n"
             "• year: One composite per year\n"
             "• quarter: One composite per quarter (3 months)\n"
             "• month: One composite per month\n"
             "• dekadal: Three composites per month (1-10, 11-20, 21-end)\n"
+            "• week: One composite per week\n"
             "• day: Daily composites (more data intensive)"
         )
         freq_layout.addWidget(self.frequency)


### PR DESCRIPTION
## Summary
- Add `dekadal` and `week` to the Imagery frequency dropdown.
- Generate calendar dekads as 1-10, 11-20, and 21 through month end for Landsat, Sentinel-1, Sentinel-2, and generated Custom XYZ dates.
- Generate weekly composites as seven-day ranges clipped to the configured season end date.
- Document the frequency options and add date sequence regression tests.

Fixes #64

## Validation
- `pre-commit run --all-files`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`