### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/timelapse/metadata.txt
+++ b/timelapse/metadata.txt
@@ -3,7 +3,7 @@ name=Timelapse
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Create timelapse animations from satellite and aerial imagery (NAIP, Landsat, Sentinel-2, Sentinel-1, GOES, MODIS NDVI, ESRI Wayback, and custom XYZ sources)
-version=0.11.2
+version=0.12.0
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -33,6 +33,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.12.0:
+        - Add dekadal (10-day) and weekly timestep options for imagery timelapse (#64)
     0.11.1:
         - Fix macOS QGIS installer dependency installation
     0.11.0:


### PR DESCRIPTION
Minor release bump in plugin metadata.

Adds dekadal (10-day) and weekly timestep options for imagery timelapse (#64), now merged into `main`.

- Bump `version` to `0.12.0` in `timelapse/metadata.txt`
- Add `0.12.0` changelog entry